### PR TITLE
API key / env variable documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ This prototype is based on the [GOV.UK prototype kit](https://github.com/alphago
 * In Terminal, change the path to the repository
 * Type `npm start`  and start the application
 
+### API keys
+
+Create a blank file named `.env` and add the following API keys:
+
+```
+HERE_GEOCODING_API_KEY=
+MAPIT_API_KEY=
+```
+
 ## Upgrading the prototype kit
 
 Based on https://govuk-prototype-kit.herokuapp.com/docs/updating-the-kit

--- a/app/services/location.js
+++ b/app/services/location.js
@@ -11,6 +11,11 @@ function _roundUp (num, precision) {
 
 const locationService = {
   async getPoint (latitude, longitude, type = 'TTW') {
+
+    if (!process.env.MAPIT_API_KEY) {
+      throw Error("Missing MAPIT_API_KEY – add it to your .env file")
+    }
+
     // Round up lat/long to reduce calls to MapIt API
     latitude = _roundUp(latitude, 3)
     longitude = _roundUp(longitude, 3)

--- a/app/utils.js
+++ b/app/utils.js
@@ -4,6 +4,10 @@ const filters = require('./filters')()
 const locationService = require('../app/services/location')
 const teacherTrainingService = require('../app/services/teacher-training')
 
+if (!process.env.HERE_GEOCODING_API_KEY) {
+  throw Error("Missing HERE_GEOCODING_API_KEY – add it to your .env file")
+}
+
 const geocoder = NodeGeocoder({
   provider: 'here',
   apiKey: process.env.HERE_GEOCODING_API_KEY,


### PR DESCRIPTION
I had to set this prototype up on a new machine again, and it took me a little while to discover all the API keys that were needed in the `.env` file.

This aims to improve this, by adding some documentation to the README, and also throwing more helpful errors if the keys are missing (in case you don’t read the README 😄).