### PR TITLE
Bugfix: filters toggle on old iPhones

### DIFF
--- a/app/assets/javascripts/components/filter-toggle-button.js
+++ b/app/assets/javascripts/components/filter-toggle-button.js
@@ -7,7 +7,7 @@ export const FilterToggleButton = class {
 
   setupResponsiveChecks () {
     this.mq = window.matchMedia(this.options.bigModeMediaQuery)
-    this.mq.addEventListener('change', $.proxy(this, 'checkMode'))
+    this.mq.addListener($.proxy(this, 'checkMode'));
     this.checkMode(this.mq)
   }
 


### PR DESCRIPTION
This fixes the Filters toggle on older versions of Safari (on older iPhones), by reverting `addEventListener` to using `addListener`.

Whilst `addListener` has been deprecated in favour of `addEventListener`, as used in the MOJ frontend version of this component: https://github.com/ministryofjustice/moj-frontend/blob/master/src/moj/components/filter-toggle-button/filter-toggle-button.js#L14

This is because `addEventListener` is only supported in Safari for `MediaQueryList` objects from version 14 onwards: https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener – and old iPhones are unable to upgrade to this.

`addListener` seems to have been maintained by browsers for backwards-compatibility, at least for now.

A better longer-term fix might be to feature-detect support for `addEventListener` and then fall back to `addListener` if that is not available. Or alternatively to rewrite the javascript so that the component at least "fails safe" and uses the no-javascript mode if any of the component javascript is unsupported.