### PR TITLE
Add international candidates section and home fee status paragraph

### DIFF
--- a/app/views/course.njk
+++ b/app/views/course.njk
@@ -64,6 +64,7 @@
           {% if course.interview_process %}
             <li><a href="#interview">Interview process</a></li>
           {% endif %}
+          <li><a href="#international-students">International students</a></li>
           <li><a href="#access-needs">Training with disabilities and other needs</a></li>
           <li><a href="#contact">Contact details</a></li>
           <li><a href="#advice">Support and advice</a></li>
@@ -199,6 +200,27 @@
           {{ course.interview_process | markdown | safe }}
         </section>
       {% endif %}
+
+      <section class="govuk-!-margin-bottom-8">
+        <h2 class="govuk-heading-l" id="international-students">International students</h2>
+
+        <p class="govuk-body">
+          {% if course.canSponsorVisa %}
+            {% if course.salaried %}
+              We can <a href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration">sponsor Skilled worker visas</a>, but this is not guaranteed.
+            {% else %}
+              We can <a href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration">sponsor Student visas</a>, but this is not guaranteed.
+            {% endif %}
+          {% else %}
+            We are unable to sponsor a visa.
+            You will need to <a class="govuk-link" href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration">get the right visa or status to {{"work" if  course.salaried else "study" }} in the UK</a>.
+          {% endif %}
+        </p>
+
+        <p class="govuk-body">You do not need a visa if you already have settled or pre-settled status under the EU Settlement Scheme, or if you are an Irish citizen.</p>
+        <p class="govuk-body">Candidates with qualifications from non-UK institutions may need to provide evidence of comparability by applying for a <a href="https://www.enic.org.uk" class="govuk-link">UK ENIC statement</a>.</p>
+
+      </section>
 
       {% if course.provider.train_with_disability %}
         <section class="govuk-!-margin-bottom-8">

--- a/app/views/course.njk
+++ b/app/views/course.njk
@@ -184,6 +184,8 @@
               <p class="govuk-body">The course fees for UK students in {{ course.year_range }} are £{{ course.fee_domestic.toLocaleString() }}.</p>
             {% endif %}
 
+            <p class="govuk-body">Some candidates, such as those with settled or pre-settled status under the EU Settlement scheme, may be <a href="https://www.gov.uk/government/publications/student-finance-eligibility-2021-to-2022-academic-year" class="govuk-body">eligible for home fee status and student finance</a>.</p>
+
             {{ course.fee_details | markdown | safe }}
           {% endif %}
         {% endif %}


### PR DESCRIPTION
This adds a new "International students" section, which explains whether visas can be sponsored for a given course or not.  (This data is not currently available but is proposed to be collected via Publish). Also adds a paragraph explaining access to home fee status for candidates with EU Settled Status, with a link to govuk.

## Screenshots

### New table of contents
<img width="510" alt="Screenshot 2021-05-13 at 10 52 09" src="https://user-images.githubusercontent.com/30665/118109577-4a414a00-b3d9-11eb-83f8-14cd0cc925eb.png">

### International students section
<img width="763" alt="Screenshot 2021-05-13 at 10 46 21" src="https://user-images.githubusercontent.com/30665/118109423-16662480-b3d9-11eb-98ee-6e1cce389916.png">

### Home fee status paragraph (in fee section)
<img width="748" alt="Screenshot 2021-05-13 at 10 47 56" src="https://user-images.githubusercontent.com/30665/118109430-1a924200-b3d9-11eb-93b2-5ff87c315100.png">
