### PR TITLE
Adding entry requirement and visa sponsorship filters

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -18,5 +18,6 @@ $git-brand-colour: #159964;
 @import "components/list";
 @import "components/pagination";
 @import "components/related";
+@import "components/result-detail";
 @import "components/search-results";
 @import "components/table";

--- a/app/assets/sass/components/_result-detail.scss
+++ b/app/assets/sass/components/_result-detail.scss
@@ -1,0 +1,44 @@
+.app-result-detail {
+  @include govuk-font($size: 19);
+  @include govuk-text-colour;
+  @include govuk-responsive-margin(6, "bottom");
+  @include govuk-media-query($from: tablet) {
+    display: table;
+    width: 100%;
+    table-layout: fixed; // Required to allow us to wrap words that overflow.
+  }
+  margin: 0; // Reset default user agent styles
+  @include govuk-responsive-margin(6, "bottom");
+}
+
+.app-result-detail__row {
+  @include govuk-media-query($until: tablet) {
+    margin-bottom: govuk-spacing(1);
+  }
+  @include govuk-media-query($from: tablet) {
+    display: table-row;
+  }
+}
+
+.app-result-detail__key {
+  @include govuk-media-query($from: tablet) {
+    color:  $govuk-secondary-text-colour;
+    width: 40%;
+  }
+}
+
+.app-result-detail__key,
+.app-result-detail__value {
+  margin: 0; // Reset default user agent styles
+
+  @include govuk-media-query($from: tablet) {
+    display: table-cell;
+    padding-top: 0;
+    padding-right: govuk-spacing(4);
+    padding-bottom: govuk-spacing(1);
+  }
+}
+
+.app-result-detail--label {
+  font-weight: bold;
+}

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -10,7 +10,8 @@ module.exports = {
     send: ['exclude'],
     studyType: ['full_time', 'part_time'],
     subjects: [],
-    vacancy: ['include']
+    vacancy: ['include'],
+    entryRequirement: ['21','22','third','degree']
   },
   londonSubRegions: [{
     text: 'Central London',
@@ -174,6 +175,24 @@ module.exports = {
     hint: 'To teach further education you don’t need QTS. Instead you can study for a PGCE or PGDE without QTS.',
     value: 'pgce,pgde'
   }],
+  entryRequirementOptions: [
+    {
+      text: '2:1 degree or higher',
+      value: '21'
+    },
+    {
+      text: '2:2 degree or higher',
+      value: '22'
+    },
+    {
+      text: 'Third class degree or higher',
+      value: 'third'
+    },
+    {
+      text: 'An undergraduate degree',
+      value: 'degree'
+    }
+  ],
   salaryOptions: [{
     text: 'Only show courses that come with a salary',
     value: ['include']

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -194,7 +194,7 @@ module.exports = {
     }
   ],
   salaryOptions: [{
-    text: 'Only show courses that come with a salary',
+    text: 'Only show courses with a salary',
     value: ['include']
   }],
   studyTypeOptions: [{

--- a/app/routes/results.js
+++ b/app/routes/results.js
@@ -40,6 +40,15 @@ module.exports = router => {
       return item
     })
 
+    // Entry Requirements
+    const entryRequirement = utils.toArray(req.session.data.entryRequirement || req.query.entryRequirement || defaults.entryRequirement)
+
+    const entryRequirementItems = utils.entryRequirementItems(entryRequirement).map(item => {
+      item.hint = false
+      item.label.classes = false
+      return item
+    })
+
     // Salary
     const salary = (req.session.data.salary && req.session.data.salary[0] === 'include') || (req.query.salary && req.query.salary[0] === 'include') || (defaults.salary[0] === 'include')
     const salaryItems = utils.salaryItems(salary)
@@ -198,7 +207,8 @@ module.exports = router => {
         studyTypeItems,
         subjectItems,
         vacancy,
-        vacancyItems
+        vacancyItems,
+        entryRequirementItems
       })
     } catch (error) {
       console.log(error.stack)

--- a/app/utils.js
+++ b/app/utils.js
@@ -149,6 +149,16 @@ module.exports = () => {
     }))
   }
 
+  utils.entryRequirementItems = (entryRequirement, options = {}) => {
+    return data.entryRequirementOptions.map(option => ({
+      value: option.value,
+      text: option.text,
+      label: { classes: 'govuk-label--s' },
+      hint: { text: options.showHintText ? filters.markdown(option.hint) : false },
+      checked: entryRequirement ? entryRequirement.includes(option.value) : false
+    }))
+  }
+
   utils.salaryItems = salary => {
     return data.salaryOptions.map(option => ({
       value: option.value,

--- a/app/views/_includes/filter.njk
+++ b/app/views/_includes/filter.njk
@@ -1,4 +1,4 @@
-  <form class="app-filter" method="post">
+<form class="app-filter" method="post">
   <div class="app-filter__header">
     <h2 class="govuk-heading-m">Filters</h2>
   </div>

--- a/app/views/_includes/filter.njk
+++ b/app/views/_includes/filter.njk
@@ -1,4 +1,4 @@
-<form class="app-filter" method="post">
+  <form class="app-filter" method="post">
   <div class="app-filter__header">
     <h2 class="govuk-heading-m">Filters</h2>
   </div>
@@ -105,11 +105,47 @@
       fieldset: {
         legend: {
           classes: "govuk-fieldset__legend--s",
+          text: "Degree requirements"
+        }
+      },
+      name: "entryRequirement",
+      items: entryRequirementItems
+    }) }}
+
+    {{ govukCheckboxes({
+      formGroup: {
+        classes: "app-filter__group"
+      },
+      classes: "govuk-checkboxes--small",
+      fieldset: {
+        legend: {
+          classes: "govuk-fieldset__legend--s",
           text: "Salary"
         }
       },
       name: "salary",
       items: salaryItems
+    }) }}
+
+    {{ govukCheckboxes({
+      formGroup: {
+        classes: "app-filter__group"
+      },
+      classes: "govuk-checkboxes--small",
+      fieldset: {
+        legend: {
+          classes: "govuk-fieldset__legend--s",
+          text: "Visa sponsorshop"
+        }
+      },
+      name: "visaSponsorship",
+      items: [
+        {
+          value: "yes",
+          text: "Only show courses where visas can be sponsored",
+          checked: (data['visaSponsorship'][0] == 'yes')
+        }
+      ]
     }) }}
 
     {{ govukButton({

--- a/app/views/_includes/filter.njk
+++ b/app/views/_includes/filter.njk
@@ -126,7 +126,7 @@
       fieldset: {
         legend: {
           classes: "govuk-fieldset__legend--s",
-          text: "Visa sponsorshop"
+          text: "Visa sponsorship"
         }
       },
       name: "visaSponsorship",

--- a/app/views/_includes/filter.njk
+++ b/app/views/_includes/filter.njk
@@ -10,17 +10,27 @@
         <p class="govuk-body-s govuk-!-margin-bottom-2">{{ provider.name }}</p>
         <p class="govuk-body-s govuk-!-margin-bottom-2"><a class="govuk-link govuk-link--no-visited-state" href="/results/filters/query">Change provider or choose a location</a></p>
       </div>
-    {% else %}
-      <div class="app-filter__group">
-        <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Area</h2>
-        {% if area %}
-          <p class="govuk-body-s govuk-!-margin-bottom-2">{{ "London" if londonBorough else area.name }}</p>
-        {% else %}
-          <p class="govuk-body-s govuk-!-margin-bottom-2">England</p>
-        {% endif %}
-        <p class="govuk-body-s govuk-!-margin-bottom-2"><a class="govuk-link govuk-link--no-visited-state" href="/results/filters/query">Change location or choose a provider</a></p>
-      </div>
-    {% endif %}
+  {% endif %}
+
+    <div class="app-filter__group">
+      <h3 class="govuk-heading-s govuk-!-margin-bottom-2">Subject{{ "s" if selectedSubjects.length > 1 }}</h3>
+      {%- set noSubjectsSelected = selectedSubjects.length == 0 -%}
+      <p class="govuk-body-s govuk-!-margin-bottom-2">{{ selectedSubjects | join(", ", "text") }}</p>
+      <p class="govuk-body-s govuk-!-margin-bottom-2"><a class="govuk-link govuk-link--no-visited-state" href="/results/filters/subject">Change<span class="govuk-visually-hidden"> subjects</span></a></p>
+    </div>
+
+  {% if not provider %}
+
+    <div class="app-filter__group">
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Area</h2>
+      {% if area %}
+        <p class="govuk-body-s govuk-!-margin-bottom-2">{{ "London" if londonBorough else area.name }}</p>
+      {% else %}
+        <p class="govuk-body-s govuk-!-margin-bottom-2">England</p>
+      {% endif %}
+      <p class="govuk-body-s govuk-!-margin-bottom-2"><a class="govuk-link govuk-link--no-visited-state" href="/results/filters/query">Change location or choose a provider</a></p>
+    </div>
+  {% endif %}
 
     {% if londonBorough and londonBoroughItems.length > 0 %}
       <div class="app-filter__group">
@@ -30,13 +40,7 @@
       </div>
     {% endif %}
 
-    <div class="app-filter__group">
-      <h3 class="govuk-heading-s govuk-!-margin-bottom-2">Subject{{ "s" if selectedSubjects.length > 1 }}</h3>
-      {%- set noSubjectsSelected = selectedSubjects.length == 0 -%}
-      <p class="govuk-body-s govuk-!-margin-bottom-2">{{ selectedSubjects | join(", ", "text") }}</p>
-      <p class="govuk-body-s govuk-!-margin-bottom-2"><a class="govuk-link govuk-link--no-visited-state" href="/results/filters/subject">Change<span class="govuk-visually-hidden"> subjects</span></a></p>
-    </div>
-
+    <!--
     {{ govukCheckboxes({
       formGroup: {
         classes: "app-filter__group"
@@ -51,21 +55,7 @@
       name: "send",
       items: sendItems
     }) }}
-
-    {{ govukCheckboxes({
-      formGroup: {
-        classes: "app-filter__group"
-      },
-      classes: "govuk-checkboxes--small",
-      fieldset: {
-        legend: {
-          classes: "govuk-fieldset__legend--s",
-          text: "Vacancies"
-        }
-      },
-      name: "vacancy",
-      items: vacancyItems
-    }) }}
+    -->
 
     {{ govukCheckboxes({
       formGroup: {
@@ -90,7 +80,7 @@
       fieldset: {
         legend: {
           classes: "govuk-fieldset__legend--s",
-          text: "Qualifications"
+          text: "Qualification"
         }
       },
       name: "qualification",
@@ -105,12 +95,13 @@
       fieldset: {
         legend: {
           classes: "govuk-fieldset__legend--s",
-          text: "Degree requirements"
+          text: "Financial support"
         }
       },
-      name: "entryRequirement",
-      items: entryRequirementItems
+      name: "salary",
+      items: salaryItems
     }) }}
+
 
     {{ govukCheckboxes({
       formGroup: {
@@ -120,11 +111,11 @@
       fieldset: {
         legend: {
           classes: "govuk-fieldset__legend--s",
-          text: "Salary"
+          text: "Degree required"
         }
       },
-      name: "salary",
-      items: salaryItems
+      name: "entryRequirement",
+      items: entryRequirementItems
     }) }}
 
     {{ govukCheckboxes({
@@ -146,6 +137,21 @@
           checked: (data['visaSponsorship'][0] == 'yes')
         }
       ]
+    }) }}
+
+    {{ govukCheckboxes({
+      formGroup: {
+        classes: "app-filter__group"
+      },
+      classes: "govuk-checkboxes--small",
+      fieldset: {
+        legend: {
+          classes: "govuk-fieldset__legend--s",
+          text: "Vacancies"
+        }
+      },
+      name: "vacancy",
+      items: vacancyItems
     }) }}
 
     {{ govukButton({

--- a/app/views/_includes/result-item.njk
+++ b/app/views/_includes/result-item.njk
@@ -4,23 +4,42 @@
     <span class="app-search-result__course-name">{{ result.course.name }} ({{ result.course.code }})</span>
   </a>
 </h2>
-<dl class="app-list--description">
-  <dt class="app-list--description__label">Qualification</dt>
-  <dd>{{ result.course.qualification }}</dd>
-  <dt class="app-list--description__label">Study type</dt>
-  <dd>{{ result.course.study_mode }}</dd>
+<dl class="app-result-detail">
   {% if result.placementAreas %}
-    <dt class="app-list--description__label">School placements</dt>
-    <dd>{{ result.placementAreas | formatList }}</dd>
+    <div class="app-result-detail__row">
+      <dt class="app-result-detail__key">School placements</dt>
+      <dd class="app-result-detail__value">{{ result.placementAreas | formatList }}</dd>
+    </div>
   {% endif %}
-  {% if result.course.accredited_body %}
-    <dt class="app-list--description__label">Accredited body</dt>
-    <dd>{{ result.course.accredited_body }}</dd>
-  {% endif %}
-  <dt class="app-list--description__label">Financial support</dt>
-  <dd>{{ "Salary" if result.course.funding_type == "salary" else "Student finance if you’re eligible" }}</dd>
-  {% if not vacancy %}
-    <dt class="app-list--description__label">Vacancies</dt>
-    <dd>{{ "Yes" if result.course.has_vacancies else "No" }}</dd>
-  {% endif %}
+  <div class="app-result-detail__row">
+    <dt class="app-result-detail__key">Study type</dt>
+    <dd class="app-result-detail__value">{{ result.course.study_mode }}</dd>
+  </div>
+  <div class="app-result-detail__row">
+    <dt class="app-result-detail__key">Qualification</dt>
+    <dd class="app-result-detail__value">{{ result.course.qualification }}</dd>
+  </div>
+
+  {# {% if result.course.accredited_body %}
+    <div class="app-result-detail__row">
+      <dt class="app-result-detail__key">Accredited body</dt>
+      <dd class="app-result-detail__value">{{ result.course.accredited_body }}</dd>
+    </div>
+  {% endif %} #}
+  <div class="app-result-detail__row">
+    <dt class="app-result-detail__key">Financial support</dt>
+    <dd class="app-result-detail__value">{{ "Salary" if result.course.funding_type == "salary" else "Student finance if you’re eligible" }}</dd>
+  </div>
+  <div class="app-result-detail__row">
+    <dt class="app-result-detail__key">Degree required</dt>
+    <dd class="app-result-detail__value">2:1 degree or higher (or equivalent)</dd>
+  </div>
+  <div class="app-result-detail__row">
+    <dt class="app-result-detail__key">Visa sponsorship</dt>
+    <dd class="app-result-detail__value">Student visas can be sponsored</dd>
+  </div>
+  <div class="app-result-detail__row">
+    <dt class="app-result-detail__key">Vacancies</dt>
+    <dd class="app-result-detail__value">{{ "Yes" if result.course.has_vacancies else "No" }}</dd>
+  </div>
 </dl>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "9.11.1",
   "private": true,
   "engines": {
-    "node": ">=10.0.0 <15.0.0"
+    "node": ">=10.0.0 <16.0.0"
   },
   "scripts": {
     "start": "node start.js",


### PR DESCRIPTION
We’re hoping to collect structured information on what the degree entry requirements for each course are, and whether each course (or provider) offers visa sponsorship or not. One of the benefits of this would be the possibility of enabling candidates to filter by these criteria.

This PR explores how that might work.

Changes:

* Added entry requirements filter. Note that this is checkboxes not radios, and refers to what the entry requirements are not what class of degree you have. I initially did that this has radios, but it felt confusing to switch from about-the-course to about-you, and also this lets people filter by courses that have a higher requirement (eg 2:1 or above) if they have a 2:1, rather than just seeing all courses which would accept their degree. Possibly useful as a proxy for more competitive courses?
* Add visa sponsorship filter.
* Re-ordered the filters and the search result listing to be in the same order (which is in rough order of 'importance').
* Tried to make the labels for the filters and search results more similar
* Removed SEND specialism filter. Partly to make space, and partly because this is also included in the Subject filter anyway.
* Removed 'Accredited by' from search results, on the basis that this isn't a filter, and is less important for comparison purposes – but would still be shown on the course page.
* Changed labels in search results from bold black to regular dark grey to put more emphasis on the text which is different across courses.

## Screenshot

![screenshot-localhost_3010-2021 05 17-14_46_43](https://user-images.githubusercontent.com/30665/118499490-e55e5a80-b71e-11eb-9d7b-d969cdb90700.png)
