### PR TITLE
Remove accordion from subject selection page

### DIFF
--- a/app/views/filters/subject.njk
+++ b/app/views/filters/subject.njk
@@ -12,45 +12,39 @@
       <h1 class="govuk-heading-l">{{ title }}</h1>
 
       <form action="/results">
-        <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
-          {% for subject in subjectItems %}
-            <div class="govuk-accordion__section">
-              <div class="govuk-accordion__section-header">
-                <h2 class="govuk-accordion__section-heading">
-                  <span class="govuk-accordion__section-button" id="accordion-default-heading-{{ loop.index }}">
-                    {{ subject.text }}
-                  </span>
-                </h2>
-              </div>
-              <div class="govuk-accordion__section-content">
-                {% if subject.text == "Primary" %}
-                  <p class="govuk-body">Trainee primary school teachers learn to teach all subjects across the national curriculum.</p>
-                  <p class="govuk-body">You can choose to add a specialist subject to your training. This could be a subject you have qualifications or experience in.</p>
-                  <p class="govuk-body">Your training will develop your knowledge of your specialist subject. This is so you can support other teachers to teach that subject.</p>
-                {% endif %}
-                {{ govukCheckboxes({
-                  name: "subjects",
-                  items: subject.items
-                }) }}
-              </div>
-            </div>
-          {% endfor %}
-          <div class="govuk-accordion__section">
-            <div class="govuk-accordion__section-header">
-              <h2 class="govuk-accordion__section-heading">
-                <span class="govuk-accordion__section-button" id="accordion-default-heading-{{ loop.index }}">
-                  Special educational needs and disability (SEND)
-                </span>
-              </h2>
-            </div>
-            <div class="govuk-accordion__section-content">
-              {{ govukCheckboxes({
-                name: "send",
-                items: sendItems
-              }) }}
-            </div>
-          </div>
-        </div>
+        {% for subject in subjectItems %}
+
+          {% if subject.text == "Primary" %}
+            {% set hintHtml %}
+              <p class="govuk-body">Trainee primary school teachers learn to teach all subjects across the national curriculum.</p>
+              <p class="govuk-body">You can choose to add a specialist subject to your training. This could be a subject you have qualifications or experience in.</p>
+              <p class="govuk-body">Your training will develop your knowledge of your specialist subject. This is so you can support other teachers to teach that subject.</p>
+            {% endset %}
+            {% set hint = {html: hintHtml} %}
+          {% else %}
+            {% set hint = {} %}
+          {% endif %}
+
+          {{ govukCheckboxes({
+            fieldset: {
+              legend: {
+                text: subject.text,
+                classes: "govuk-fieldset__legend--m"
+              }
+            },
+            hint: hint,
+            name: "subjects",
+            items: subject.items
+          }) }}
+        {% endfor %}
+        <h2 class="govuk-heading-m">
+          Special educational needs and disability (SEND)
+        </h2>
+        {{ govukCheckboxes({
+          name: "send",
+          items: sendItems
+        }) }}
+
         {{ govukButton({
           text: "Find courses"
         }) }}


### PR DESCRIPTION
This page currently uses checkboxes within an accordion. I think this is probably not ideal for both accessibility and usability reasons:

* the accordion has [known accessibility issues](https://design-system.service.gov.uk/components/accordion/#known-issues-and-gaps). An upcoming [design change](https://github.com/alphagov/govuk-design-system-backlog/issues/1#issuecomment-839802842) is being worked on by the GOV.UK team, but this will take up more space.
* when you return to the subject filters page via the "Change" link on Find, it is unclear whether we should prioritise opening the sections that contain a checked checkbox (so you can see them) or restoring the state that you previously left the page in (which is what the javascript currently does).
* The checkboxes are currently semantically linked with a visually-hidden "Choose from the following [subject heading] subjects", which is verbose and duplicates the visually displayed subject heading.

Removing the accordion and using regular fieldsets with legends fixes results in a simpler layout and fixes the accessibility issues.

The one remaining question is whether the text under the "Primary" legend is too long as hint text (which gets semantically linked to the fieldset via `aria-describedby`), as it can end up getting read out after every checkbox, eg using VoiceOver.

Another possibility is to reduce the list by asking an initial branching question of "Do you want to teach Primary or Secondary?" (assuming that it’s unlikely you’d want to see both at the same time)

## Before

### Accordion closed

![screenshot-localhost_3010-2021 05 17-16_50_10](https://user-images.githubusercontent.com/30665/118518404-ffecff80-b72f-11eb-9ddd-369b5a765713.png)

### Accordion open

![screenshot-localhost_3010-2021 05 17-16_34_29](https://user-images.githubusercontent.com/30665/118518436-08ddd100-b730-11eb-87c8-9e04c3159cc3.png)

## After

![screenshot-localhost_3010-2021 05 17-16_33_57](https://user-images.githubusercontent.com/30665/118518477-11360c00-b730-11eb-9340-6e4487efd460.png)
