### PR TITLE
Splitting subjects across separate Primary and Secondary routes

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -189,7 +189,7 @@ module.exports = {
       value: 'third'
     },
     {
-      text: 'An undergraduate degree',
+      text: 'Any undergraduate degree',
       value: 'degree'
     }
   ],

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -252,7 +252,13 @@ module.exports = {
     text: 'Primary with science',
     type: 'primary',
     value: '07'
-  }, {
+  },
+  {
+    text: 'Special education needs and disability (SEND)',
+    type: 'primary',
+    value: 'SEND'
+  },
+   {
     text: 'Art and design',
     type: 'secondary',
     value: 'W1'
@@ -402,7 +408,11 @@ module.exports = {
     hint: 'Bursaries of £10,000 available.',
     type: 'secondary_language',
     value: '22'
-  }, {
+  },{
+    text: 'Special educational needs and disability (SEND)',
+    type: 'secondary',
+    value: 'SEND'
+  },{
     text: 'Further education',
     type: 'further_education',
     value: '41'

--- a/app/routes/start.js
+++ b/app/routes/start.js
@@ -115,7 +115,7 @@ module.exports = router => {
 
   router.get('/', async (req, res) => {
     // Reset data
-    req.session.data = {}
+    // req.session.data = {}
     res.render('index')
   })
 }

--- a/app/routes/start.js
+++ b/app/routes/start.js
@@ -9,7 +9,7 @@ module.exports = router => {
     if (queryType === 'area' && filtering) {
       res.redirect(req.session.data.area.type === 'LBO' ? '/results/filters/london' : '/results/filters/subject')
     } else if (queryType === 'area') {
-      res.redirect(req.session.data.area.type === 'LBO' ? '/london' : '/subject')
+      res.redirect(req.session.data.area.type === 'LBO' ? '/london' : '/age-group')
     } else {
       res.redirect(queryType === 'provider' ? '/results' : '/age-group')
     }
@@ -98,7 +98,7 @@ module.exports = router => {
         south: utils.londonBoroughItems(req.session.data.londonBorough, { regionFilter: 'south' }),
         west: utils.londonBoroughItems(req.session.data.londonBorough, { regionFilter: 'west' })
       },
-      next: '/subject',
+      next: '/age-group',
       startFlow: true
     })
   })

--- a/app/routes/start.js
+++ b/app/routes/start.js
@@ -11,9 +11,50 @@ module.exports = router => {
     } else if (queryType === 'area') {
       res.redirect(req.session.data.area.type === 'LBO' ? '/london' : '/subject')
     } else {
-      res.redirect(queryType === 'provider' ? '/results' : '/subject')
+      res.redirect(queryType === 'provider' ? '/results' : '/age-group')
     }
   })
+
+  router.get('/age-group', async (req, res) => {
+    res.render('filters/age-group')
+  })
+
+  router.post('/age-group', async (req, res) => {
+    const ageGroupAnswer = req.body.ageGroup
+
+    if (ageGroupAnswer == "primary") {
+      res.redirect('/primary')
+    } else if (ageGroupAnswer == "secondary") {
+      res.redirect('/subject')
+    } else {
+      res.render('filters/age-group')
+    }
+  })
+
+  router.get('/primary', async (req, res) => {
+    res.render('filters/primary')
+  })
+
+  router.post('/primary', async (req, res) => {
+    const primarySpecialistSubjectsAnswer = req.body.primarySpecialistSubjects
+
+    if (primarySpecialistSubjectsAnswer == "yes") {
+      res.redirect('/primary-specialist-subject')
+    } else if (primarySpecialistSubjectsAnswer == "no") {
+
+      // set subject to "Primary" only
+      req.session.data.subjects = ["00"]
+
+      res.redirect('/results')
+    } else {
+      res.render('filters/primary')
+    }
+  })
+
+  router.get('/primary-specialist-subject', async (req, res) => {
+    res.render('filters/primary-specialist-subject')
+  })
+
 
   router.get('/subject', async (req, res) => {
     const q = req.session.data.q || req.query.q

--- a/app/views/_includes/filter.njk
+++ b/app/views/_includes/filter.njk
@@ -12,14 +12,14 @@
       </div>
   {% endif %}
 
-    <div class="app-filter__group">
+    {# <div class="app-filter__group">
       <h3 class="govuk-heading-s govuk-!-margin-bottom-2">Subject{{ "s" if selectedSubjects.length > 1 }}</h3>
       {%- set noSubjectsSelected = selectedSubjects.length == 0 -%}
       <p class="govuk-body-s govuk-!-margin-bottom-2">{{ selectedSubjects | join(", ", "text") }}</p>
       <p class="govuk-body-s govuk-!-margin-bottom-2"><a class="govuk-link govuk-link--no-visited-state" href="/results/filters/subject">Change<span class="govuk-visually-hidden"> subjects</span></a></p>
-    </div>
+    </div> #}
 
-  {% if not provider %}
+  {# {% if not provider %}
 
     <div class="app-filter__group">
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Area</h2>
@@ -30,7 +30,7 @@
       {% endif %}
       <p class="govuk-body-s govuk-!-margin-bottom-2"><a class="govuk-link govuk-link--no-visited-state" href="/results/filters/query">Change location or choose a provider</a></p>
     </div>
-  {% endif %}
+  {% endif %} #}
 
     {% if londonBorough and londonBoroughItems.length > 0 %}
       <div class="app-filter__group">

--- a/app/views/filters/age-group.njk
+++ b/app/views/filters/age-group.njk
@@ -25,11 +25,13 @@
           items: [
             {
               value: "primary",
-              text: "Primary"
+              text: "Primary",
+              checked: (data["ageGroup"] == "primary")
             },
             {
               value: "secondary",
-              text: "Secondary"
+              text: "Secondary",
+              checked: (data["ageGroup"] == "secondary")
             }
           ]
         }) }}

--- a/app/views/filters/age-group.njk
+++ b/app/views/filters/age-group.njk
@@ -1,0 +1,43 @@
+{% extends "_layouts/default.njk" %}
+
+{% set title = "Which age group do you want to teach?" %}
+
+{% block pageNavigation %}
+  {{ govukBackLink(backLink) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form action="/age-group" method="POST">
+        {% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+        {{ govukRadios({
+          idPrefix: "age-group",
+          name: "ageGroup",
+          fieldset: {
+            legend: {
+              text: title,
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          items: [
+            {
+              value: "primary",
+              text: "Primary"
+            },
+            {
+              value: "secondary",
+              text: "Secondary"
+            }
+          ]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/filters/age-group.njk
+++ b/app/views/filters/age-group.njk
@@ -3,7 +3,7 @@
 {% set title = "Which age group do you want to teach?" %}
 
 {% block pageNavigation %}
-  {{ govukBackLink(backLink) }}
+  {{ govukBackLink({href: "/"}) }}
 {% endblock %}
 
 {% block content %}

--- a/app/views/filters/primary-specialist-subject.njk
+++ b/app/views/filters/primary-specialist-subject.njk
@@ -1,0 +1,63 @@
+{% extends "_layouts/default.njk" %}
+
+{% set title = "Which Primary specialist subject do you want to teach?" %}
+
+{% block pageNavigation %}
+  {{ govukBackLink(backLink) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form action="/results">
+
+        {% set items = [
+          {
+            text: 'English',
+            value: '01'
+          },
+          {
+            text: 'Geography and history',
+            value: '02'
+          },
+          {
+            text: 'Mathematics',
+            value: '03'
+          },
+          {
+            text: 'Modern languages',
+            value: '04'
+          },
+          {
+            text: 'Physical education',
+            value: '06'
+          },
+          {
+            text: 'Science',
+            value: '07'
+          },
+          {
+            text: 'Also show me Primary courses without a specialist subject',
+            value: '00'
+          }
+        ] %}
+
+
+          {{ govukCheckboxes({
+            fieldset: {
+              legend: {
+                text: title,
+                classes: "govuk-fieldset__legend--l"
+              }
+            },
+            name: "subjects",
+            items: items
+          }) }}
+
+        {{ govukButton({
+          text: "Find courses"
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/filters/primary-specialist-subject.njk
+++ b/app/views/filters/primary-specialist-subject.njk
@@ -3,7 +3,7 @@
 {% set title = "Which Primary specialist subject do you want to teach?" %}
 
 {% block pageNavigation %}
-  {{ govukBackLink(backLink) }}
+  {{ govukBackLink({href: "/primary"}) }}
 {% endblock %}
 
 {% block content %}

--- a/app/views/filters/primary-specialist-subject.njk
+++ b/app/views/filters/primary-specialist-subject.njk
@@ -1,6 +1,6 @@
 {% extends "_layouts/default.njk" %}
 
-{% set title = "Which Primary specialist subject do you want to teach?" %}
+{% set title = "Which specialist subjects are you interested in?" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({href: "/primary"}) }}
@@ -35,6 +35,10 @@
           {
             text: 'Science',
             value: '07'
+          },
+          {
+            text: 'Special education needs and disability (SEND)',
+            value: 'SEND'
           },
           {
             text: 'Also show me Primary courses without a specialist subject',

--- a/app/views/filters/primary.njk
+++ b/app/views/filters/primary.njk
@@ -3,7 +3,7 @@
 {% set title = "Would you like to find Primary courses which include a specialist subject?" %}
 
 {% block pageNavigation %}
-  {{ govukBackLink(backLink) }}
+  {{ govukBackLink({href: "/age-group"}) }}
 {% endblock %}
 
 {% block content %}

--- a/app/views/filters/primary.njk
+++ b/app/views/filters/primary.njk
@@ -1,0 +1,45 @@
+{% extends "_layouts/default.njk" %}
+
+{% set title = "Would you like to find Primary courses which include a specialist subject?" %}
+
+{% block pageNavigation %}
+  {{ govukBackLink(backLink) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form action="/primary" method="POST">
+        {% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+        {{ govukRadios({
+          name: "primarySpecialistSubjects",
+          fieldset: {
+            legend: {
+              text: title,
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          hint: {
+            text: "Primary courses with a specialist subject will develop your knowledge of that subject so that you can support other teachers."
+          },
+          items: [
+            {
+              value: "yes",
+              text: "Yes, show me the specialist subjects"
+            },
+            {
+              value: "no",
+              text: "No, just show me Primary courses"
+            }
+          ]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/filters/primary.njk
+++ b/app/views/filters/primary.njk
@@ -27,11 +27,13 @@
           items: [
             {
               value: "yes",
-              text: "Yes, show me the specialist subjects"
+              text: "Yes, show me the specialist subjects",
+              checked: (data["primarySpecialistSubjects"] == "yes")
             },
             {
               value: "no",
-              text: "No, just show me Primary courses"
+              text: "No, just show me Primary courses",
+              checked: (data["primarySpecialistSubjects"] == "no")
             }
           ]
         }) }}

--- a/app/views/filters/subject.njk
+++ b/app/views/filters/subject.njk
@@ -3,7 +3,7 @@
 {% set title = "Which Secondary subject do you want to teach?" %}
 
 {% block pageNavigation %}
-  {{ govukBackLink(backLink) }}
+  {{ govukBackLink({href: "/age-group"}) }}
 {% endblock %}
 
 {% block content %}

--- a/app/views/filters/subject.njk
+++ b/app/views/filters/subject.njk
@@ -1,6 +1,6 @@
 {% extends "_layouts/default.njk" %}
 
-{% set title = "Which Secondary subject do you want to teach?" %}
+{% set title = "Which Secondary subjects are you interested in?" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({href: "/age-group"}) }}

--- a/app/views/filters/subject.njk
+++ b/app/views/filters/subject.njk
@@ -1,6 +1,6 @@
 {% extends "_layouts/default.njk" %}
 
-{% set title = "Select the subjects you want to teach" %}
+{% set title = "Which Secondary subject do you want to teach?" %}
 
 {% block pageNavigation %}
   {{ govukBackLink(backLink) }}
@@ -12,38 +12,30 @@
       <h1 class="govuk-heading-l">{{ title }}</h1>
 
       <form action="/results">
+        {% set items = [] %}
         {% for subject in subjectItems %}
 
-          {% if subject.text == "Primary" %}
-            {% set hintHtml %}
-              <p class="govuk-body">Trainee primary school teachers learn to teach all subjects across the national curriculum.</p>
-              <p class="govuk-body">You can choose to add a specialist subject to your training. This could be a subject you have qualifications or experience in.</p>
-              <p class="govuk-body">Your training will develop your knowledge of your specialist subject. This is so you can support other teachers to teach that subject.</p>
-            {% endset %}
-            {% set hint = {html: hintHtml} %}
-          {% else %}
-            {% set hint = {} %}
+          {% if subject.text == "Secondary" or subject.text == "Secondary: Modern languages" %}
+            {% for item in subject.items %}
+              {% set items = items | push(item) %}
+            {% endfor %}
           {% endif %}
-
-          {{ govukCheckboxes({
-            fieldset: {
-              legend: {
-                text: subject.text,
-                classes: "govuk-fieldset__legend--m"
-              }
-            },
-            hint: hint,
-            name: "subjects",
-            items: subject.items
-          }) }}
         {% endfor %}
-        <h2 class="govuk-heading-m">
-          Special educational needs and disability (SEND)
-        </h2>
+
         {{ govukCheckboxes({
-          name: "send",
-          items: sendItems
+          fieldset: {
+            legend: {
+              text: subject.text,
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          hint: {
+            text: "Select all subjects you are interested in teaching"
+          },
+          name: "subjects",
+          items: (items | sort(attribute="text") )
         }) }}
+
 
         {{ govukButton({
           text: "Find courses"

--- a/app/views/results.njk
+++ b/app/views/results.njk
@@ -3,8 +3,13 @@
 {% set title = resultsCount + " courses found" %}
 
 {% block content %}
+
+<div class="govuk-body">
+  <b>{{ selectedSubjects | join("</b> and <b>", "text") }}</b> courses in <b>{% if area %}{{ londonBorough if londonBorough else "London" }}{% else %}England{% endif %}</b>
+  <a href="/" class="govuk-link govuk-!-margin-left-4">Change</a>
+</div>
+
   <h1 class="govuk-heading-l">
-    <span class="govuk-caption-l">Teacher training courses</span>
     {% if results | length > 0 %}
       {{ resultsCount }} courses found
     {% else %}

--- a/app/views/results.njk
+++ b/app/views/results.njk
@@ -5,7 +5,7 @@
 {% block content %}
 
 <div class="govuk-body">
-  <b>{{ selectedSubjects | join("</b> and <b>", "text") }}</b> courses in <b>{% if area %}{{ londonBorough if londonBorough else "London" }}{% else %}England{% endif %}</b>
+  <b>{{ selectedSubjects | join("</b> and <b>", "text") }}</b> courses in <b>{% if area %}{{ londonBoroughItems | join("</b>, <b>", "text") if londonBorough else area.name }}{% else %}England{% endif %}</b>
   <a href="/" class="govuk-link govuk-!-margin-left-4">Change</a>
 </div>
 


### PR DESCRIPTION
This builds upon https://github.com/DFE-Digital/find-teacher-training-prototype/pull/30 which dropped the accordion in favour of a list of checkboxes, for accessibility and usability reasons.

As a further enhancement, this PR makes the list of checkboxes more usable by first asking whether someone wants to teach Primary or Secondary aged children. This is based on the assumption that few teachers are unsure about this at this stage, and that the likelihood of wanting to search for Primary AND Secondary courses at the same time is low.

For Primary, a follow-up guard question is used to introduce the notion of the specialist subject, which is then followed by a list of specialist subjects if the candidate is interested.

For Secondary, the list of subjects is presented as a single alphabetical list (including all the languages subjects) to aid scanning.

The results page needs some further thought, but an initial idea is to remove the age group / subjects from the Filter box altogether, in order to make the other filters (which the candidate hasn't yet seen) more visible, and all behave in the same way.

Instead, the age group and subject(s) are shown at the top of the page in place of the static caption, with a "Change" link. This takes you back to the homepage where you can go through the flow again - but your previous answers are remembered.

TODO:

* [x] consider how SEND specialist courses should be treated. As a separate filter, or part of the initial subject flow?
* [x] work out what happens when you click "Change" for the age group and subjects
* [ ] is the content about scholarships and bursaries in the right place (subject hint text)?
* [x] would it be better to have the list of Primary or Secondary subjects as checkbox filters (optionally with search)?
* [x] should the Find homepage also contain a list of popular course types (like Primary, English, etc) which could link direct to results?

## Screenshots

![screenshot-localhost_3010-2021 05 28-17_22_23](https://user-images.githubusercontent.com/30665/120232291-3146ee80-c24b-11eb-9f15-2cb745fe545f.png)

![screenshot-localhost_3010-2021 05 28-17_22_44](https://user-images.githubusercontent.com/30665/120232299-35730c00-c24b-11eb-825e-e279e9eb2fc8.png)

![screenshot-localhost_3010-2021 05 28-17_23_07](https://user-images.githubusercontent.com/30665/120232312-3b68ed00-c24b-11eb-94d1-4de30b7c84d9.png)

![screenshot-localhost_3010-2021 05 31-20_04_11](https://user-images.githubusercontent.com/30665/120232428-78cd7a80-c24b-11eb-86d7-2a42022060ec.png)

![screenshot-localhost_3010-2021 05 28-17_24_38](https://user-images.githubusercontent.com/30665/120232352-50458080-c24b-11eb-9d72-1bab1b24e40d.png)
