### PR TITLE
Show actual distance from nearest placement or university campus

### DIFF
--- a/app/assets/sass/components/_result-detail.scss
+++ b/app/assets/sass/components/_result-detail.scss
@@ -20,16 +20,6 @@
   }
 }
 
-.app-result-detail__key {
-  font-weight: bold;
-
-  @include govuk-media-query($from: tablet) {
-    color:  $govuk-secondary-text-colour;
-    font-weight: normal;
-    width: 40%;
-  }
-}
-
 .app-result-detail__key,
 .app-result-detail__value {
   margin: 0; // Reset default user agent styles
@@ -48,6 +38,16 @@
   .govuk-hint {
     @include govuk-font($size: 16);
     margin-bottom: govuk-spacing(1);
+  }
+}
+
+.app-result-detail__key {
+  font-weight: bold;
+
+  @include govuk-media-query($from: tablet) {
+    color:  $govuk-secondary-text-colour;
+    font-weight: normal;
+    width: 200px;
   }
 }
 

--- a/app/views/_components/result-detail/template.njk
+++ b/app/views/_components/result-detail/template.njk
@@ -9,28 +9,28 @@
 </h2>
 <dl class="app-result-detail">
   <div class="app-result-detail__row">
-    <dt class="app-result-detail__key">Nearest placement</dt>
+  {% if params.schools and params.schools | length > 0 %}
+    <dt class="app-result-detail__key">Nearest location</dt>
     <dd class="app-result-detail__value">
       {% if params.schools | length > 0 %}
-        <p class="govuk-body">6 miles from you</p>
+        <p class="govuk-body">{{ params.schools[0].distance }} miles from you</p>
         <p class="govuk-hint">{{ params.schools[0].name }}, {{ params.schools[0].address }}</p>
         {% if params.schools | length > 1 %}
-          <p class="govuk-hint">Nearest of {{ params.schools | length }} locations. Next nearest is {{ params.schools[1].distance + 1 }} miles from you.</p>
+          <p class="govuk-hint">Nearest of {{ params.schools | length }} locations. Next nearest is {{ params.schools[1].distance }} miles from you.</p>
         {% endif %}
-      {% else %}
-        6 miles from you
       {% endif %}
     </dd>
   </div>
+  {% endif %}
   {% if params.placementAreas and showPlacementAreas %}
     <div class="app-result-detail__row">
-      <dt class="app-result-detail__key">Placements</dt>
+      <dt class="app-result-detail__key">Placement areas</dt>
       <dd class="app-result-detail__value">{{ params.placementAreas }}</dd>
     </div>
   {% endif %}
   {% if params.trainingLocation %}
     <div class="app-result-detail__row">
-      <dt class="app-result-detail__key">Training centre</dt>
+      <dt class="app-result-detail__key">University location</dt>
       <dd class="app-result-detail__value">
         <p class="govuk-body">{{ params.trainingLocation.distance }} miles from you</p>
         <p class="govuk-hint">{{ params.trainingLocation.address }}</p>

--- a/app/views/results.njk
+++ b/app/views/results.njk
@@ -45,7 +45,7 @@
         <div class="app-search-results-header">
           <form class="app-search-results-header__sort" data-qa="sort-form" action="/results" accept-charset="UTF-8" data-remote="true" method="get">
 
-            {{ govukSelect({
+          {{ govukSelect({
             id: "sortby",
             name: "sortby",
             attributes: { onchange: "this.form.submit()" },
@@ -54,18 +54,15 @@
               text: "Sorted by",
               classes: "govuk-!-display-inline-block"
             },
-            items: [
-              {
-                value: "0",
-                text: "Training provider (A-Z)",
-                selected: (data.sortby == "0")
-              },
-              {
-                value: "1",
-                text: "Training provider (Z-A)",
-                selected: (data.sortby == "1")
-              }
-            ]
+            items: [{
+              value: "0",
+              text: "Training provider (A-Z)",
+              selected: (data.sortby == "0")
+            }, {
+              value: "1",
+              text: "Training provider (Z-A)",
+              selected: (data.sortby == "1")
+            }]
           }) }}
           </form>
           <p class="govuk-body">
@@ -78,12 +75,19 @@
         <ul class="app-search-results">
         {% for result in results %}
           <li class="app-search-results__item">
+            {% set isLocationSearch = data.q != "england" %}
+            {% set isUniversity = result.provider.provider_type == "university" %}
+            {% set trainingLocation = result.course.trainingLocation %}
+
             {{ appResultDetail({
               href: "/course/" + result.provider.code + "/" + result.course.code,
               providerName: result.provider.name | markdown("inline"),
               courseName: result.course.name + " (" + result.course.code + ")",
-              placementAreas: result.placementAreas | formatList,
-              schools: result.schools,
+              schools: result.schools if not isUniversity and isLocationSearch,
+              trainingLocation: {
+                distance: trainingLocation.distance,
+                address: trainingLocation.address
+              } if trainingLocation and isUniversity and isLocationSearch,
               accreditedBody: result.course.accredited_body,
               studyMode: result.course.study_mode,
               qualification: result.course.qualification,

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "express": "^4.17.1",
     "express-session": "^1.17.0",
     "fancy-log": "^1.3.3",
+    "geolib": "^3.3.1",
     "got": "^11.8.2",
     "govuk-frontend": "^3.13.0",
     "gulp": "^4.0.2",


### PR DESCRIPTION
Adds distance information to locations in search results:

If `provider_type` is university, show distance to university campus, else show distance to nearest location (we can assume it’s a placement school for now) and next nearest location if there’s more than 1 school location: 

<img width="650" alt="Screenshot 2021-07-07 at 17 25 52" src="https://user-images.githubusercontent.com/813383/124795902-79db8100-df48-11eb-9eb2-7914ffbca828.png">

Still need to hide this location information if you’re searching across England.