### PR TITLE
Add end of cycle banner message

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -1,6 +1,7 @@
 module.exports = {
   apiEndpoint: 'https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1',
   cycle: 2021,
+  nearingEndOfCycle: true,
   defaults: {
     latitude: false,
     longitude: false,

--- a/app/views/_includes/nearing-end-of-cycle-banner.njk
+++ b/app/views/_includes/nearing-end-of-cycle-banner.njk
@@ -1,0 +1,9 @@
+{% set nearingEndOfCycleHtml %}
+  <p class="govuk-notification-banner__heading">Apply now to get on a course starting in the 2021 to 2022 academic year</p>
+  <p class="govuk-body">Courses can fill up at any time, so you should apply as soon as you can.</p>
+  <p class="govuk-body">If you’re applying for the first time since applications opened in October 2020, apply no later than 6pm on 7 September 2021.</p>
+  <p class="govuk-body">If your application did not lead to a place and you’re applying again, apply no later than 6pm on 20 September 2021.</p>
+{% endset %}
+{{ govukNotificationBanner({
+  html: nearingEndOfCycleHtml
+}) if data.nearingEndOfCycle }}

--- a/app/views/_layouts/default.njk
+++ b/app/views/_layouts/default.njk
@@ -66,26 +66,25 @@
 
   {% block pageNavigation %}{% endblock %}
 {% endblock %}
+
 {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}
 
-{% if useAutoStoreData %}
-  {% block footer %}
-    {{ govukFooter({
-      meta: {
-        items: [{
-          href: "https://govuk-prototype-kit.herokuapp.com/",
-          text: "GOV.UK Prototype Kit " + releaseVersion
-        }, {
-          href: "/admin/clear-data",
-          text: "Clear data"
-        }, {
-          href: "/admin/feature-flags",
-          text: "Feature flags"
-        }]
-      }
-    }) }}
-  {% endblock %}
-{% endif %}
+{% block footer %}
+  {{ govukFooter({
+    meta: {
+      items: [{
+        href: "https://govuk-prototype-kit.herokuapp.com/",
+        text: "GOV.UK Prototype Kit " + releaseVersion
+      }, {
+        href: "/admin/clear-data",
+        text: "Clear data"
+      } if useAutoStoreData, {
+        href: "/admin/feature-flags",
+        text: "Feature flags"
+      }]
+    }
+  }) }}
+{% endblock %}
 
 {% block bodyEnd %}
   {% block scripts %}

--- a/app/views/course.njk
+++ b/app/views/course.njk
@@ -10,6 +10,8 @@
 {% endblock %}
 
 {% block content %}
+  {% include "_includes/nearing-end-of-cycle-banner.njk" %}
+
   <h1 class="govuk-heading-xl">
     <span class="govuk-heading-l govuk-!-margin-bottom-1">{{ course.provider.name }}</span>
     {{ course.name }} ({{ course.code }})

--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -10,6 +10,8 @@
 {% endblock %}
 
 {% block content %}
+  {% include "_includes/nearing-end-of-cycle-banner.njk" %}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <form action="/search" method="post">

--- a/app/views/results.njk
+++ b/app/views/results.njk
@@ -3,19 +3,20 @@
 {% set title = resultsCount + " courses found" %}
 
 {% block content %}
+  {% include "_includes/nearing-end-of-cycle-banner.njk" %}
 
-<p class="govuk-body govuk-!-margin-bottom-0">
-  <b>{{ selectedSubjects | join("</b> and <b>", "text") }}</b> courses
+  <p class="govuk-body govuk-!-margin-bottom-0">
+    <b>{{ selectedSubjects | join("</b> and <b>", "text") }}</b> courses
 
-  {% if data.q == "england" %}
-    in <b>England</b>
-  {% elif data.q == "location" %}
-    in <b>{{ data.locationName }}</b>
-  {% elif data.q == "provider" %}
-    from <b>{{ provider.name }}</b>
-  {% endif %}
-  <a href="/" class="govuk-link govuk-!-margin-left-4">Change <span class="govuk-visually-hidden">subject or location</span></a>
-</p>
+    {% if data.q == "england" %}
+      in <b>England</b>
+    {% elif data.q == "location" %}
+      in <b>{{ data.locationName }}</b>
+    {% elif data.q == "provider" %}
+      from <b>{{ provider.name }}</b>
+    {% endif %}
+    <a href="/" class="govuk-link govuk-!-margin-left-4">Change <span class="govuk-visually-hidden">subject or location</span></a>
+  </p>
 
   <h1 class="govuk-heading-l">
     {% if resultsCount > 0 %}


### PR DESCRIPTION
The following banner is shown on:

* homepage
* search results page
* course details page

<img width="1010" alt="Screenshot 2021-07-08 at 17 27 42" src="https://user-images.githubusercontent.com/813383/124958236-d6ef3980-e011-11eb-96c7-1b2739dec67a.png">
