### PR TITLE
Change wording for "Any undergraduate degree"

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -186,7 +186,7 @@ module.exports = {
     text: 'Third class degree or higher',
     value: 'third'
   }, {
-    text: 'Any undergraduate degree',
+    text: 'Any degree grade',
     value: 'degree'
   }],
   salaryOptions: [{

--- a/app/views/_components/result-detail/template.njk
+++ b/app/views/_components/result-detail/template.njk
@@ -68,7 +68,7 @@
       {% elif params.degree == "third" %}
         Third class degree or higher (or equivalent)
       {% else %}
-        Any undergraduate degree
+        Any degree grade
       {% endif %}
     </dd>
   </div>


### PR DESCRIPTION
We saw in research that one participant interpreted "Any undergraduate degree" as meaning "Any undergraduate degree subject".  This isn't necessarily the case for secondary courses, where the degree may need to match the subject being taught.

Changing the wording to "Any degree grade" should help resolve this.

We did consider "Any degree class" but thought that "class" would be less familiar than "grade", especially for international candidates.

## Screenshots

### Before

<img width="342" alt="Screenshot 2021-07-26 at 13 43 08" src="https://user-images.githubusercontent.com/30665/126990571-3506a57c-55da-454f-86b6-2e85a08eb17f.png">

### After

<img width="339" alt="Screenshot 2021-07-26 at 13 39 28" src="https://user-images.githubusercontent.com/30665/126990542-0adfdabf-8d27-4a1a-b74c-da7e3941782e.png">

