### PR TITLE
Update entry requirement wording

### DIFF
--- a/app/utils.js
+++ b/app/utils.js
@@ -50,7 +50,7 @@ module.exports = () => {
 
     // Adding degree subject requirement unless it’s primary
     if (course.name !== 'Primary') {
-      course.requirements.degree.subject = `Your degree subject should be in ${course.name} or a similar subject. Otherwise you will need to demonstrate subject knowledge in some other way.`
+      course.requirements.degree.subject = `50% of your degree modules should be in the subject.`
     }
 
     // Randomising whether pending GCSEs are accepted or not.

--- a/app/utils.js
+++ b/app/utils.js
@@ -53,7 +53,48 @@ module.exports = () => {
       course.requirements.degree.subject = `Your degree subject should be in ${course.name} or a similar subject. Otherwise you will need to demonstrate subject knowledge in some other way.`
     }
 
-    // Adding random GCSE flexibility options
+    // Randomising whether pending GCSEs are accepted or not.
+    switch (getRandomInt(2)) {
+      case 0:
+        course.requirements.gcses.pendingGcsesAccepted = true
+        break
+      default:
+        course.requirements.gcses.pendingGcsesAccepted = false
+        break
+    }
+
+    // Randomising whether equivalency tests accepted or not.
+    switch (getRandomInt(2)) {
+      case 0:
+        course.requirements.gcses.equivalencyTestsAccepted = true
+        break
+      default:
+        course.requirements.gcses.equivalencyTestsAccepted = false
+        break
+    }
+
+    if (course.requirements.gcses.equivalencyTestsAccepted) {
+      // Randomising which subjects tests accepted for
+      switch (getRandomInt(5)) {
+      case 0:
+        course.requirements.gcses.equivalencyTestSubjects = ["maths"]
+        break
+      case 1:
+        course.requirements.gcses.equivalencyTestSubjects = ["English"]
+        break
+      case 2:
+        course.requirements.gcses.equivalencyTestSubjects = ["English", "maths"]
+      default:
+        if (course.name == "Primary") {
+          course.requirements.gcses.equivalencyTestSubjects = ["English", "maths", "science"]
+        } else {
+          course.requirements.gcses.equivalencyTestSubjects = ["English", "maths"]
+        }
+        break
+      }
+    }
+
+
     switch (getRandomInt(5)) {
       case 0:
         course.requirements.gcses.maths.flexibility = 'must'

--- a/app/views/course.njk
+++ b/app/views/course.njk
@@ -322,7 +322,7 @@
         <p class="govuk-body">
           {% if course.canSponsorVisa %}
             {% if course.salaried %}
-              We can <a href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration">sponsor Skilled worker visas</a>.
+              We can <a href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration">sponsor Skilled Worker visas</a>.
             {% else %}
               We can <a href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration">sponsor Student visas</a>.
             {% endif %}

--- a/app/views/course.njk
+++ b/app/views/course.njk
@@ -168,12 +168,15 @@
           {% endif %}
         </p>
 
+
+        {% if course.name !== "Primary"  %}
+          <p class="govuk-body">Your degree subject should be in {{ course.name }} or a similar subject. Otherwise you’ll need to prove your subject knowledge in some other way.</p>
+        {% endif %}
+
         {% if course.requirements.degree.subject %}
           <p class="govuk-body">
             {{ course.requirements.degree.subject }}
           </p>
-        {% elif course.name !== "Primary"  %}
-          <p class="govuk-body">Your degree subject should be in {{ course.name }} or a similar subject. Otherwise you’ll need to demonstrate subject knowledge in some other way.</p>
         {% endif %}
 
         <p class="govuk-body">GCSE grade 4 (C) or above in English{{", maths and science" if course.name === "Primary" else " and maths" }}, or an equivalent qualification.</p>

--- a/app/views/course.njk
+++ b/app/views/course.njk
@@ -179,7 +179,7 @@
           </p>
         {% endif %}
 
-        <p class="govuk-body">GCSE grade 4 (C) or above in English{{", maths and science" if course.name === "Primary" else " and maths" }}, or an equivalent qualification.</p>
+        <p class="govuk-body">GCSE grade 4 (C) or above in English{{", maths and science" if course.name === "Primary" else " and maths" }}, or equivalent qualification.</p>
 
         <p class="govuk-body">
           {% if course.requirements.gcses.pendingGcsesAccepted == true %}

--- a/app/views/course.njk
+++ b/app/views/course.njk
@@ -183,13 +183,13 @@
 
         <p class="govuk-body">
           {% if course.requirements.gcses.pendingGcsesAccepted == true %}
-            We will consider candidates who are currently taking GCSEs.
+            We’ll consider candidates who are currently taking GCSEs.
           {% else %}
             We will not consider candidates with pending GCSEs.
           {% endif %}
 
           {% if course.requirements.gcses.equivalencyTestsAccepted == true %}
-            We will consider candidates who need to take a GCSE equivalency test in {{ course.requirements.gcses.equivalencyTestSubjects | formatOrList }}.
+            We’ll consider candidates who need to take a GCSE equivalency test in {{ course.requirements.gcses.equivalencyTestSubjects | formatOrList }}.
           {% else %}
             We will not consider candidates who need to take GCSE equivalency tests.
           {% endif %}
@@ -328,7 +328,7 @@
             {% endif %}
           {% else %}
             We’re unable to sponsor visas.
-            You will need to <a class="govuk-link" href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration">get the right visa or status to {{"work" if  course.salaried else "study" }} in the UK</a>.
+            You’ll need to <a class="govuk-link" href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration">get the right visa or status to {{"work" if  course.salaried else "study" }} in the UK</a>.
           {% endif %}
         </p>
 

--- a/app/views/course.njk
+++ b/app/views/course.njk
@@ -182,7 +182,7 @@
           {% if course.requirements.gcses.pendingGcsesAccepted == true %}
             We will consider candidates who are currently taking GCSEs.
           {% else %}
-            We do not consider candidates with pending GCSEs.
+            We will not consider candidates with pending GCSEs.
           {% endif %}
 
           {% if course.requirements.gcses.equivalencyTestsAccepted == true %}

--- a/app/views/course.njk
+++ b/app/views/course.njk
@@ -172,53 +172,25 @@
           <p class="govuk-body">
             {{ course.requirements.degree.subject }}
           </p>
+        {% elif course.name !== "Primary"  %}
+          <p class="govuk-body">Your degree subject should be in {{ course.name }} or a similar subject. Otherwise you’ll need to demonstrate subject knowledge in some other way.</p>
         {% endif %}
 
-        <p class="govuk-body">GCSE grade 4 (C) or above in English{{", maths and science" if course.name === "Primary" else " and maths" }}, or equivalent.</p>
+        <p class="govuk-body">GCSE grade 4 (C) or above in English{{", maths and science" if course.name === "Primary" else " and maths" }}, or an equivalent qualification.</p>
 
-        {% set englishGcseFlexibility = course.requirements.gcses.english.flexibility %}
-        {% set mathsGcseFlexibility = course.requirements.gcses.maths.flexibility %}
-        {% set scienceGcseFlexibility = course.requirements.gcses.science.flexibility %}
+        <p class="govuk-body">
+          {% if course.requirements.gcses.pendingGcsesAccepted == true %}
+            We will consider candidates who are currently taking GCSEs.
+          {% else %}
+            We do not consider candidates with pending GCSEs.
+          {% endif %}
 
-        {% set subjectsMustHave = [] %}
-        {% set subjectsCanBePending = [] %}
-        {% set subjectsPendingOrEquivalencyTests = [] %}
-
-        {% if englishGcseFlexibility === "pending" %}
-          {% set subjectsCanBePending = subjectsCanBePending | push("English") %}
-        {% elif englishGcseFlexibility === "must" %}
-          {% set subjectsMustHave = subjectsMustHave | push("English") %}
-        {% elif englishGcseFlexibility === "equivalency-test-offered" %}
-          {% set subjectsPendingOrEquivalencyTests = subjectsPendingOrEquivalencyTests | push("English") %}
-        {% endif %}
-
-        {% if mathsGcseFlexibility === "pending" %}
-          {% set subjectsCanBePending = subjectsCanBePending | push("maths") %}
-        {% elif mathsGcseFlexibility === "must" %}
-          {% set subjectsMustHave = subjectsMustHave | push("maths") %}
-        {% elif mathsGcseFlexibility === "equivalency-test-offered" %}
-          {% set subjectsPendingOrEquivalencyTests = subjectsPendingOrEquivalencyTests | push("maths") %}
-        {% endif %}
-
-        {% if scienceGcseFlexibility === "pending" %}
-          {% set subjectsCanBePending = subjectsCanBePending | push("science") %}
-        {% elif scienceGcseFlexibility === "must" %}
-          {% set subjectsMustHave = subjectsMustHave | push("science") %}
-        {% elif scienceGcseFlexibility === "equivalency-test-offered" %}
-          {% set subjectsPendingOrEquivalencyTests = subjectsPendingOrEquivalencyTests | push("science") %}
-        {% endif %}
-
-        {% if subjectsMustHave | length > 0 %}
-          <p class="govuk-body">Equivalency tests will not be offered for {{ subjectsMustHave | formatOrList }}.</p>
-        {% endif %}
-
-        {% if subjectsCanBePending | length > 0 %}
-          <p class="govuk-body">Candidates who are currently taking their {{"a" if (subjectsCanBePending | length) === 1 }} {{ subjectsCanBePending | formatOrList }} GCSE{{"s" if (subjectsCanBePending | length) > 1 }} will be considered, but equivalency tests will not be offered.</p>
-        {% endif %}
-
-        {% if subjectsPendingOrEquivalencyTests | length > 0 %}
-          <p class="govuk-body">You can ask to take an equivalency test for {{ subjectsPendingOrEquivalencyTests | formatOrList }}. You will also be considered if you are currently taking {{"a" if (subjectsCanBePending | length) === 1 }} {{ subjectsCanBePending | formatOrList }} GCSE{{"s" if (subjectsPendingOrEquivalencyTests | length) > 1 }}.</p>
-        {% endif %}
+          {% if course.requirements.gcses.equivalencyTestsAccepted == true %}
+            We accept GCSE equivalency tests in {{ course.requirements.gcses.equivalencyTestSubjects | formatList }}.
+          {% else %}
+            We do not accept GCSE equivalency tests.
+          {% endif %}
+        </p>
 
         {% if course.personal_qualities %}
           <h3 class="govuk-heading-m" id="personal-qualities">Personal qualities</h3>

--- a/app/views/course.njk
+++ b/app/views/course.njk
@@ -189,9 +189,9 @@
           {% endif %}
 
           {% if course.requirements.gcses.equivalencyTestsAccepted == true %}
-            We accept GCSE equivalency tests in {{ course.requirements.gcses.equivalencyTestSubjects | formatList }}.
+            We will consider candidates who need to take a GCSE equivalency test in {{ course.requirements.gcses.equivalencyTestSubjects | formatOrList }}.
           {% else %}
-            We do not accept GCSE equivalency tests.
+            We will not consider candidates who need to take GCSE equivalency tests.
           {% endif %}
         </p>
 

--- a/app/views/course.njk
+++ b/app/views/course.njk
@@ -327,12 +327,12 @@
               We can <a href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration">sponsor Student visas</a>.
             {% endif %}
           {% else %}
-            We are unable to sponsor a visa.
+            We’re unable to sponsor visas.
             You will need to <a class="govuk-link" href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration">get the right visa or status to {{"work" if  course.salaried else "study" }} in the UK</a>.
           {% endif %}
         </p>
 
-        <p class="govuk-body">You do not need a visa if you already have settled or pre-settled status under the EU Settlement Scheme, or if you are an Irish citizen.</p>
+        <p class="govuk-body">You do not need a visa if you already have settled or pre-settled status under the EU Settlement Scheme, or if you’re an Irish citizen.</p>
         <p class="govuk-body">Candidates with qualifications from non-UK institutions may need to provide evidence of comparability by applying for a <a href="https://www.enic.org.uk" class="govuk-link">UK ENIC statement</a>.</p>
       </div>
     </div>

--- a/app/views/course.njk
+++ b/app/views/course.njk
@@ -319,9 +319,9 @@
         <p class="govuk-body">
           {% if course.canSponsorVisa %}
             {% if course.salaried %}
-              We can <a href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration">sponsor Skilled worker visas</a>, but this is not guaranteed.
+              We can <a href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration">sponsor Skilled worker visas</a>.
             {% else %}
-              We can <a href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration">sponsor Student visas</a>, but this is not guaranteed.
+              We can <a href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration">sponsor Student visas</a>.
             {% endif %}
           {% else %}
             We are unable to sponsor a visa.


### PR DESCRIPTION
Updates following another content reviewing following another round of testing.

These changes:

* update the prototype to reflect changes in Publish (ie that accepting pending GCSEs isn't subject-specific).
* make "equivalent" vs "equivalency tests" clearer by using "equivalent qualification" and "GCSE equivalency tests"
* use contractions – "we’re" instead of "we are"
* made the language around considering candidates who need to take an equivalency test clearer (hopefully)
* removes "but this is not guaranteed." from visa section, as this was unclear and probably unnecessary.

Once these have been merged we'll need to copy across the changes to the course preview in the Publish prototype.
