### PR TITLE
Remove "New search" link

### DIFF
--- a/app/views/results.njk
+++ b/app/views/results.njk
@@ -37,10 +37,6 @@
       {% if data.q == "location" %}
         <div class="app-search-results-header">
          <p class="govuk-body">Sorted by distance</p>
-
-         <p class="govuk-body">
-            <a class="govuk-link govuk-link--no-visited-state" href="/">New search</a>
-          </p>
         </div>
       {% elif data.q == "england" %}
         <div class="app-search-results-header">
@@ -66,9 +62,6 @@
             }]
           }) }}
           </form>
-          <p class="govuk-body">
-            <a class="govuk-link govuk-link--no-visited-state" href="/">New search</a>
-          </p>
         </div>
       {% endif %}
 


### PR DESCRIPTION
This is overly prominent in mobile views, and duplicates the functionality of the "Change" link before the h1.

One user clicked it in research (on mobile) seemingly accidentally.