### PR TITLE
Move SEND specialism back to filters list

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -250,10 +250,6 @@ module.exports = {
     type: 'primary',
     value: '07'
   }, {
-    text: 'Special education needs and disability (SEND)',
-    type: 'primary',
-    value: 'SEND'
-  }, {
     text: 'Art and design',
     type: 'secondary',
     value: 'W1'
@@ -419,10 +415,6 @@ module.exports = {
     type: 'secondary_language',
     value: '22',
     hasSke: true
-  }, {
-    text: 'Special educational needs and disability (SEND)',
-    type: 'secondary',
-    value: 'SEND'
   }, {
     text: 'Further education',
     type: 'further_education',

--- a/app/views/_includes/filter.njk
+++ b/app/views/_includes/filter.njk
@@ -105,6 +105,21 @@
     }) }}
 
     {{ govukCheckboxes({
+       formGroup: {
+         classes: "app-filter__group"
+       },
+       classes: "govuk-checkboxes--small",
+       fieldset: {
+         legend: {
+           classes: "govuk-fieldset__legend--s",
+           text: "Special educational needs"
+         }
+       },
+       name: "send",
+       items: sendItems
+     }) }}
+
+    {{ govukCheckboxes({
       formGroup: {
         classes: "app-filter__group"
       },

--- a/app/views/filters/primary-specialist-subject.njk
+++ b/app/views/filters/primary-specialist-subject.njk
@@ -44,11 +44,6 @@
             checked: (data.subjects and data.subjects.includes('07'))
           },
           {
-            text: 'Special education needs and disability (SEND)',
-            value: 'SEND',
-            checked: (data.subjects and data.subjects.includes('SEND'))
-          },
-          {
             divider: '&nbsp;'
           },
           {


### PR DESCRIPTION
As part of the changes to the subject flow, we tried including "Special education needs and disability (SEND)" within the list of subject specialisms checkboxes for both primary and secondary. However, this doesn’t really make sense, as whilst it is a specialism, it is not really a "subject".

The current pattern on the live site is to have a separate checkbox on the subject page which is labelled as "Show only courses with a SEND specialism":

<img width="664" alt="Screenshot 2021-08-20 at 11 52 34" src="https://user-images.githubusercontent.com/30665/130222897-ef2ecd5a-ad9b-4f22-97cc-f9ee7576a98e.png">

However including this within the new subjects pages would be confusing, as it would still visually appear to be part of the "Which specialist subjects are you interested in?" question, even though it is a separate question, and the checkbox behaves differently from the other checkboxes (combining with them using AND instead of OR).

Instead, the simplest initial thing to do is to remove SEND as a checkbox from both the primary and secondary subject pages, and return it to the results page as a separate filter.

In future, we can review usage of this filter, alongside other issues around SEND-specialist courses (such as whether it is used consistently by providers) to decide whether or not to make further changes.