### PR TITLE
Change wording for degree filter

### DIFF
--- a/app/views/_includes/filter.njk
+++ b/app/views/_includes/filter.njk
@@ -59,25 +59,23 @@
       fieldset: {
         legend: {
           classes: "govuk-fieldset__legend--s",
-          text: "Degree required"
+          text: "Degree grade accepted"
         }
       },
       name: "entryRequirement",
       items: [
         {
-          text: 'Show all courses',
+          text: '2:1 or First',
           value: 'all',
           checked: true
         }, {
-          divider: "or"
-        }, {
-          text: 'Only show courses that accept a 2:2 degree',
+          text: '2:2',
           value: '22'
         }, {
-          text: 'Only show courses that accept a Third class degree',
+          text: 'Third',
           value: 'third'
         }, {
-          text: 'Only show courses that accept any degree grade',
+          text: 'Pass (Ordinary degree)',
           value: 'degree'
         }
       ]


### PR DESCRIPTION
User testing has shown that the degree grade filter is still confusing - particularly the first and last options. Some users were interpreting "Show all courses" as including courses that didn't require a degree.

This is an attempt to clarify things by explicitly labelling the last option as "Pass (Ordinary degree)" and the first option as "2:1 or First".  Hopefully users will naturally select the degree grade that they have.

## Before

<img width="359" alt="Screenshot 2021-09-06 at 11 46 06" src="https://user-images.githubusercontent.com/30665/132205662-e23d2181-3d90-4d3c-bbe7-d4cb348565a3.png">

## After

<img width="370" alt="Screenshot 2021-09-06 at 11 45 10" src="https://user-images.githubusercontent.com/30665/132205685-e4365061-c9db-499d-9771-06d19c1dde37.png">
