### PR TITLE
Adding a link to GIT from school placements

### DIFF
--- a/app/views/course/sections/school-placements/where-you-will-train-hei.md
+++ b/app/views/course/sections/school-placements/where-you-will-train-hei.md
@@ -3,3 +3,5 @@ You’ll be placed in schools for most of your course. Your school placements wi
 You can’t pick which schools you want to be in, but your university will try to take your journey time into consideration.
 
 Universities can work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.
+
+[Find out more about what to expect during your teacher training](https://getintoteaching.education.gov.uk/train-to-be-a-teacher/initial-teacher-training).

--- a/app/views/course/sections/school-placements/where-you-will-train-scitt.md
+++ b/app/views/course/sections/school-placements/where-you-will-train-scitt.md
@@ -1,1 +1,3 @@
 You’ll be placed in different schools during your training. You can’t pick which schools you want to be in, but your course will try to place you in schools you can commute to.
+
+[Find out more about what to expect during your teacher training](https://getintoteaching.education.gov.uk/train-to-be-a-teacher/initial-teacher-training).


### PR DESCRIPTION
Added a link to GIT to the 'Teacher training' page from the 'School placements' section for both HEI and SCITT versions.