### PR TITLE
Update engineers teach physics course filter parameter

### DIFF
--- a/app/controllers/results.js
+++ b/app/controllers/results.js
@@ -430,8 +430,7 @@ exports.list = async (req, res) => {
   }
 
   if (selectedCampaign[0] === 'include') {
-    // filter.campaign_name = 'engineers_teach_physics'
-    filter.engineers_teach_physics = true
+    filter.campaign_name = 'engineers_teach_physics'
   }
 
 


### PR DESCRIPTION
The filter parameter for ‘Engineers teach physics’ has changed from `engineers_teach_physics=true` to `campaign_name='engineers_teach_physics'`.

https://api.publish-teacher-training-courses.service.gov.uk/docs/api-reference.html#schema-coursefilter