### PR TITLE
Course pages 2024 p1 p2 changes

### DIFF
--- a/app/views/course/about-provider-2024.njk
+++ b/app/views/course/about-provider-2024.njk
@@ -12,18 +12,8 @@
       href: actions.back
     }) }}
 
-    <!--About the provider-->
-    <h1 class="govuk-heading-xl">
-      About {{ course.provider.name }}
-    </h1>
-
-    {% if course.provider.train_with_us %}
-      {{ course.provider.train_with_us | markdown | safe }}
-    {% endif %}
-    <!--END About the provider-->
-
-    <!--Contact provider-->
-    <h2 class="govuk-heading-l">
+<!--Contact provider-->
+    <h2 class="govuk-heading-xl">
       Contact
       {{ course.provider.name }}
     </h2>
@@ -73,6 +63,16 @@
       </div>
     </dl>
     <!--END Contact provider-->
+
+    <!--About the provider-->
+    <h1 class="govuk-heading-l">
+      About {{ course.provider.name }}
+    </h1>
+
+    {% if course.provider.train_with_us %}
+      {{ course.provider.train_with_us | markdown | safe }}
+    {% endif %}
+    <!--END About the provider-->
 
   </div>
 </div>

--- a/app/views/course/index-2024.njk
+++ b/app/views/course/index-2024.njk
@@ -70,6 +70,8 @@
 
       {% include "./sections/support-and-advice-2024.njk" %}
 
+      {% include "./sections/apply.njk" %}
+
     </div>
   </div>
 

--- a/app/views/course/sections/about-course-2024.njk
+++ b/app/views/course/sections/about-course-2024.njk
@@ -28,6 +28,28 @@
         </h2>
       </div>
       <div id="accordion-default-content-3" class="govuk-accordion__section-content">
+       <dl class="govuk-summary-list govuk-summary-list--no-border">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+              Course fee for {{ course.year_range }}
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {% if course.has_fees %}
+                {% if course.fee_domestic %}
+                  {% if course.fee_international %}
+                      <strong>£{{ course.fee_domestic | numeral('0,0') }}</strong> for UK students<br>
+                      <strong>£{{ course.fee_international | numeral('0,0') }}</strong> for Non-UK students
+                  {% else %}
+                      <strong>£{{ course.fee_domestic | numeral('0,0') }}</strong> for UK students
+                  {% endif %}
+                {% endif %}
+                {% else %}
+                    <strong>Salary</strong> - no fee
+              {% endif %}
+            </dd>
+          </div>
+        </dl>
+
         {% if course.has_fees %}
           {% if course.fee_domestic %}
             {% if course.fee_details %}
@@ -88,6 +110,17 @@
           </h2>
         </div>
         <div id="accordion-default-content-2" class="govuk-accordion__section-content">
+        <dl class="govuk-summary-list govuk-summary-list--no-border">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+              Nearest school
+          </dt>
+          <dd class="govuk-summary-list__value">
+                <strong>{{ distance.distance }} miles</strong> from <strong>{{ data.location }}</strong>
+            </dd>
+          </div>
+        </dl>
+
         {% if course.how_school_placements_work %}
           {{ course.how_school_placements_work | markdown | safe }}
         {% endif %}

--- a/app/views/course/training-with-disabilities-2024.njk
+++ b/app/views/course/training-with-disabilities-2024.njk
@@ -19,6 +19,11 @@
     {{ course.provider.train_with_disability | markdown | safe }}
     <!--END Training with disabilities-->
 
+    <p class="govuk-body">
+     <a href="/providers/{{ course.provider.code }}/courses/{{course.code}}/about-provider">
+        Contact {{ course.provider.name }}
+      </a>
+    </p>
 
   </div>
 </div>


### PR DESCRIPTION
### 1. Two participants have looked at the bottom of the page for the apply button

So we are iterating to add a button to apply at the bottom of the page.

![Screenshot 2024-05-28 at 11 07 46](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/f1ba7427-8245-4c8e-9bf4-3fe1bcbcf7aa)

### 2.  Two participants have not been able to find the provider contact details easily at the bottom of the about the provider page

So we are swapping the order of the about the provider and contact the provider information. 

![localhost_3010_providers_2BD_courses_39BV_about-provider](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/3710bbd3-c0ff-410b-abc0-e8e980936862)

### 3. One participant with access needs wanted to be able to contact the provider after reading the information about training with disabilities

So we are adding a link to the bottom of the page to contact the provider

![localhost_3010_providers_1CS_courses_2DGZ_training-with-disabilities](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/b22c35c3-170b-4b10-9abd-eacec16abfbe)

### 4. We are missing the key info on fees and nearest school placements in the accordion section, as it is currently only displayed in the call out boxes on the left of the page

So we are adding this information into the accordion.

![localhost_3010_providers_1CS_courses_2DGZ (1)](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/7b52f7df-e5cb-4794-be2b-f41bbe4245c2)
