### PR TITLE
Fix bug displaying different distances on course summary and course page

### DIFF
--- a/app/controllers/courses.js
+++ b/app/controllers/courses.js
@@ -254,6 +254,10 @@ exports.show = async (req, res) => {
       back = `/providers/${req.params.providerCode}`
     }
 
+    req.session.data.courseDistances.sort((a, b) => {
+      return a.distance - b.distance
+    })
+
     const distance = req.session.data.courseDistances.find(course => course.code === courseCode)
 
     res.render('course/index-2024', {


### PR DESCRIPTION
### Current behaviour

The distance on the course summary and course page doesn't match:

![Screenshot 2024-05-28 at 11 45 18](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/21e3f418-a30e-4efe-a30d-5e752672f62f)
![Screenshot 2024-05-28 at 11 45 22](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/1708b377-54a6-43b9-b3ec-b5e06dd83721)

### Expected behaviour

The distance on the course summary and course page matches:
![Screenshot 2024-05-28 at 11 45 18](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/0163be0e-5dda-4532-b484-8eca0fc5c1bf)
![Screenshot 2024-05-28 at 12 29 19](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/280b7a93-5107-44fb-a9c3-61bea548cd56)