### PR TITLE
Fix school placement content and salary colour

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -139,7 +139,7 @@ flex-grow: 1; /* default 0 */
   }
 
   .salary-bg {
-    background-color: #4c2c92;
+    background-color: #912b88;
     margin-bottom: 30px;
     }
 // Nearest placement call out box

--- a/app/views/course/school-placements-2024.njk
+++ b/app/views/course/school-placements-2024.njk
@@ -41,7 +41,7 @@
       You can’t pick which schools you will be in, but we will place you in ones you can travel to.
     </p>
     <p class="govuk-body">
-      The schools you could be placed in is:
+      The schools you could be placed in are:
     </p>
     {#{{ data.place.geometry | dump | safe }}#}
 


### PR DESCRIPTION
### Fix salary colour

Changed from 'purple' to 'bright-purple', as purple is already being used for non-uk citizens.

### Content changes to school placements

Changes from 'is' to 'are' on school placements page.