### PR TITLE
Course pages 2024 p4 changes

### DIFF
--- a/app/views/course/about-provider-2024.njk
+++ b/app/views/course/about-provider-2024.njk
@@ -25,7 +25,7 @@
           School website
         </dt>
         <dd class="govuk-summary-list__value">
-         <a class="govuk-link" href="{{ course.provider.website }}">{{ course.provider.website }}</a>
+         <a class="govuk-link" href="{{ course.provider.website }}" target="_blank">{{ course.provider.name }} website (opens in a new tab)</a>
         </dd>
       </div>
       {% endif %}

--- a/app/views/course/sections/about-course-2024.njk
+++ b/app/views/course/sections/about-course-2024.njk
@@ -29,7 +29,7 @@
       </div>
       <div id="accordion-default-content-3" class="govuk-accordion__section-content">
 
-      <div style="margin-bottom:40px;">
+      <div>
         <p class="govuk-body">
           <strong>
             Fees for {{ course.year_range }}:
@@ -113,7 +113,7 @@
         </div>
         <div id="accordion-default-content-2" class="govuk-accordion__section-content">
 
-        <div style="margin-bottom:30px;">
+        <div>
           {% if schools.length > 1 %}
             <p class="govuk-body">
               {{ course.provider.name }} works with {{ schools.length }} school {{- "s" if schools.length > 1 }}.
@@ -186,7 +186,7 @@
                 </div>
                 <span class="govuk-body">
                   <strong>
-                    {{ distance.distance }} miles
+                    {{ distance.distance }} mile {{- "s" if distance.distance > 1 }}
                   </strong>
                     from
                   <strong>

--- a/app/views/course/sections/nearest-placement-2024.njk
+++ b/app/views/course/sections/nearest-placement-2024.njk
@@ -68,7 +68,7 @@
               </div>
               <span class="govuk-body">
                 <strong>
-                  {{ distance.distance }} miles
+                  {{ distance.distance }} mile {{- "s" if distance.distance > 1 }}
                 </strong>
                   from
                 <strong>

--- a/app/views/results/_result-item-2024.njk
+++ b/app/views/results/_result-item-2024.njk
@@ -15,23 +15,29 @@
 
   <div class="govuk-summary-card__content">
     <dl class="govuk-summary-list">
-    {% if result.schools and result.schools | length > 0 %}
+    {#{% if result.schools and result.schools | length > 0 %}#}
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           Nearest school
         </dt>
         <dd class="app-result-detail__value">
           {% if result.schools | length > 0 %}
-            <span class="govuk-body"><strong>{{ result.schools[0].distance }} miles</strong> from <strong>{{ data.location }}</strong></span><br>
-              {% if result.schools | length > 1 %}
-                <p class="govuk-hint govuk-!-font-size-16">
-                Nearest of {{ result.schools | length }} school {{- "s" if result.schools.length > 1 }} you could be placed in
-              {% endif %}
+            <span class="govuk-body">
+              <strong>{{ result.schools[0].distance }} mile {{- "s" if result.schools[0].distance > 1 }}</strong> from <strong>{{ data.location }}</strong>
+            </span><br>
+          {% if result.schools | length > 1 %}
+            <p class="govuk-hint govuk-!-font-size-16">
+              Nearest of {{ result.schools | length }} school {{- "s" if result.schools.length > 1 }} you could be placed in
             </p>
           {% endif %}
+          {% else %}
+            <a href="#">
+              Contact the provider
+            </a>
+        {% endif %}
         </dd>
       </div>
-      {% endif %}
+      {#{% endif %}#}
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
             Course fee


### PR DESCRIPTION
### Updated miles to show singular

Where miles was displayed, added logic to make miles singular when it was only 1 mile away.

- Summary card on search results
- Nearest school placement call out box
- How placements work accordion

![Screenshot 2024-05-31 at 16 55 59](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/1c4cb5c9-9567-47d1-9b13-7961212cdfb1)

### Update website formate and open in a new window

- Updated the link to target="_blank"
- Updated the format to match Teacher Vacancies, so it displays the provider name instead of the URL

![Screenshot 2024-05-31 at 16 53 42](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/10b2ed40-c4a7-4e98-8210-6cd39e0933f2)

### Update nearest school logic to always display the row

Added a link to contact the provider when location is not able to be determined.

![Screenshot 2024-05-31 at 16 54 41](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/6a2744ed-f25c-46ee-b131-de5ccd1d4bd9)