### PR TITLE
Update content from students to citizens

### DIFF
--- a/app/views/course-2024/index.njk
+++ b/app/views/course-2024/index.njk
@@ -32,7 +32,7 @@
         <div class="fee-container">
           <div class="fee-item">
             <p class="fee-key">
-              UK students
+              UK citizens
             </p>
             <h3 class="fee-value">
               £9,250
@@ -40,7 +40,7 @@
           </div>
           <div class="fee-item">
             <p class="fee-key">
-              Non-UK students
+              Non-UK citizens
             </p>
             <h3 class="fee-value">
               £17,325

--- a/app/views/course-2024/results-2024.njk
+++ b/app/views/course-2024/results-2024.njk
@@ -46,7 +46,7 @@
           <dd class="govuk-summary-list__value">
             <strong>
               £8,750
-            </strong> for UK students
+            </strong> for UK citizens
           </dd>
           <dd class="govuk-summary-list__actions">
           </dd>
@@ -140,10 +140,10 @@
           <dd class="govuk-summary-list__value">
             <strong>
               £9,250
-            </strong> for UK students<br>
+            </strong> for UK citizens<br>
             <strong>
               £17,250
-            </strong> for Non-UK students
+            </strong> for Non-UK citizens
           </dd>
           <dd class="govuk-summary-list__actions">
           </dd>

--- a/app/views/course/sections/about-course-2024.njk
+++ b/app/views/course/sections/about-course-2024.njk
@@ -39,10 +39,10 @@
           {% if course.has_fees %}
             {% if course.fee_domestic %}
               {% if course.fee_international %}
-                <strong>£{{ course.fee_domestic | numeral('0,0') }}</strong> for UK students<br>
-                <strong>£{{ course.fee_international | numeral('0,0') }}</strong> for Non-UK students
+                <strong>£{{ course.fee_domestic | numeral('0,0') }}</strong> for UK citizens<br>
+                <strong>£{{ course.fee_international | numeral('0,0') }}</strong> for Non-UK citizens
               {% else %}
-                <strong>£{{ course.fee_domestic | numeral('0,0') }}</strong> for UK students
+                <strong>£{{ course.fee_domestic | numeral('0,0') }}</strong> for UK citizens
               {% endif %}
             {% endif %}
             {% else %}

--- a/app/views/course/sections/fee-box-2024.njk
+++ b/app/views/course/sections/fee-box-2024.njk
@@ -11,7 +11,7 @@
         <div class="fee-container">
           <div class="fee-item">
             <p class="fee-key">
-              UK students
+              UK citizens
             </p>
             <h3 class="fee-value">
               £{{ course.fee_domestic | numeral('0,0') }}
@@ -19,7 +19,7 @@
           </div>
           <div class="fee-item">
             <p class="fee-key">
-              Non-UK students
+              Non-UK citizens
             </p>
             <h3 class="fee-value">
               £{{ course.fee_international | numeral('0,0') }}
@@ -40,7 +40,7 @@
         <div class="fee-container">
           <div class="fee-item">
             <p class="fee-key">
-              UK students
+              UK citizens
             </p>
             <h3 class="fee-value">
               £{{ course.fee_domestic | numeral('0,0') }}

--- a/app/views/results/_result-item-2024.njk
+++ b/app/views/results/_result-item-2024.njk
@@ -44,10 +44,10 @@
           {% if result.course.has_fees %}
               {% if result.course.fee_domestic %}
                 {% if result.course.fee_international %}
-                  <span class="govuk-body"><strong>£{{ result.course.fee_domestic | numeral('0,0') }}</strong> for UK students</span>
-                  <p class="govuk-body"><strong>£{{ result.course.fee_international | numeral('0,0') }}</strong> for Non-UK students</p>
+                  <span class="govuk-body"><strong>£{{ result.course.fee_domestic | numeral('0,0') }}</strong> for UK citizens</span>
+                  <p class="govuk-body"><strong>£{{ result.course.fee_international | numeral('0,0') }}</strong> for Non-UK citizens</p>
                 {% else %}
-                  <p class="govuk-body"><strong>£{{ result.course.fee_domestic | numeral('0,0') }}</strong> for UK students</p>
+                  <p class="govuk-body"><strong>£{{ result.course.fee_domestic | numeral('0,0') }}</strong> for UK citizens</p>
                 {% endif %}
               {% endif %}
               {% else %}


### PR DESCRIPTION
### Update content from students to citizens

In the service we are now using the term "Non-UK citizens" instead of "International students".

However, we still had the old terminology in the prototype when referring to the course fees. So we have updating the content for consistency.

| Before | After | 
| --- | --- |
| ![Screenshot 2024-06-04 at 07 01 39](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/9112528f-d5fc-4431-a947-1b6da72b0369) | ![Screenshot 2024-06-04 at 07 01 54](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/8350020a-9d92-4373-afb4-bb1777ef79b8) |
| ![Screenshot 2024-06-04 at 07 02 01](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/78364930-6436-4676-adf1-5b32ca7968b6) | ![Screenshot 2024-06-04 at 07 02 07](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/c5e07f71-5d49-4fba-a2f1-86bf1327f861) |
| ![Screenshot 2024-06-04 at 07 02 31](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/9d8a9b1f-4d3d-408f-b680-d1b3c54ba276) | ![Screenshot 2024-06-04 at 07 02 35](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/ce9978e1-df9e-482a-b543-e04938bd3b72) |


