### PR TITLE
Fix salary colour

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -139,7 +139,7 @@ flex-grow: 1; /* default 0 */
   }
 
   .salary-bg {
-    background-color: #912b88;
+    background-color: #1d70b8;
     margin-bottom: 30px;
     }
 // Nearest placement call out box


### PR DESCRIPTION
### Fix salary colour

We have been exploring visually differentiating between fee-based and salary-based courses. 

We are not relying on colour to convey information, but instead using it as an enhancement. 

We also want to align as close as possible to the [Get into Teaching](https://getintoteaching.education.gov.uk/) brand. 

We were trying the "[bright purple](https://design-system.service.gov.uk/styles/colour/)" colour on the gou.uk design system, however we realised that isn't closely related to the Get into Teach brand. 

So we have changed the colour for salaried courses from bright purple to the gov.uk blue.

| Before | After |
| --- | --- |
| ![find-training-prototype herokuapp com_providers_P58_courses_Z608](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/9664371a-cb3d-44b5-bf68-a4903e165001) | ![localhost_3010_providers_P58_courses_Z608](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/76448de0-99bb-4fce-b4d9-5aaca37756b0) |

| Get into Teaching website |
| --- |
| ![getintoteaching education gov uk_](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/a930e0a3-0f2e-4fe0-be10-116b4aec8a3f) |