### PR TITLE
Fix salary alignment

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -105,6 +105,15 @@ color: #fff;
   margin-bottom: 0;
   }
 
+  .salary-value {
+    color: #fff;
+    margin-bottom: 24px;
+
+    @include govuk-media-query($from: tablet) {
+      margin-bottom: 30px;
+    }
+  }
+
 .fee-title {
   color: #fff;
   font-weight: 700;

--- a/app/views/course/sections/fee-box-2024.njk
+++ b/app/views/course/sections/fee-box-2024.njk
@@ -60,8 +60,14 @@
           <p class="fee-title">
             Fees for {{ course.year_range }}
           </p>
-            <span class="fee-value"><strong>No fee</strong></span>
-            <p class="fee-key">You will be paid a salary</p><br>
+          <span class="fee-value">
+            <strong>
+              No fee
+            </strong>
+          </span>
+          <p class="salary-value">
+            You will be paid a salary
+          </p>
          <p class="govuk-body">
           <a href="#accordion-fees-financial-support" style="color:#ffffff;">
             Fees and financial support


### PR DESCRIPTION
### Fix salary alignment

The salary call out box on the course pages was slightly jumping when switching tabs, as a <br> was used instead of margin.

This was fixed so that the alignment in the same if switching between fee-based and salary-based courses.