### PR TITLE
Add degree subject requirements

### DIFF
--- a/app/views/course/sections/summary-2024.njk
+++ b/app/views/course/sections/summary-2024.njk
@@ -105,6 +105,40 @@
                 <span class="govuk-body">Bachelor's degree</span>
                 <p class="govuk-hint govuk-!-font-size-16">or equivalent qualification</p>
               {% endif %}
+
+              {% if course.degree_subject_requirements != null or course.campaign_name == "engineers_teach_physics" or course.has_ske %}
+                <details class="govuk-details">
+                  <summary class="govuk-details__summary">
+                    <span class="govuk-details__summary-text">
+                      Degree subject requirements
+                    </span>
+                  </summary>
+                  <div class="govuk-details__text">
+
+                  {% if course.degree_subject_requirements %}
+                    {% if course.campaign_name != "engineers_teach_physics" %}
+                      <p class="govuk-body">
+                        {{ course.degree_subject_requirements | markdown | safe }}
+                      </p>
+                    {% endif %}
+                  {% endif %}
+
+                  {% if course.campaign_name == "engineers_teach_physics" %}
+                    <p class="govuk-body">
+                      This <a class="govuk-link" href="https://getintoteaching.education.gov.uk/subjects/engineers-teach-physics">Engineers teach physics</a> course is designed for candidates who have a background in materials science and engineering. If your degree is in physics, please apply to our physics course.
+                    </p>
+                  {% endif %}
+
+                  {% if course.has_ske %}
+                    <p class="govuk-body">
+                      If you need to improve your subject knowledge, you may be asked to complete a <a class="govuk-link" href="https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement">subject knowledge enhancement</a> course.
+                    </p>
+                  {% endif %}
+
+                  </div>
+                </details>
+              {% endif %}
+
             </dd>
           </div>
           <div class="govuk-summary-list__row">


### PR DESCRIPTION
### Add degree subject requirements

Multiple participants have wanted to see more information about the degree requirements. This information is on the live site, and was not added to the initial prototype. We have now added this information for further testing.

| Before |
| --- |
| ![Screenshot 2024-06-04 at 15 53 43](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/3bfcd82e-b8f4-4ef1-843d-54e95bc9dfe2) |

| With SKE | With additional info from the provider and SKE |
| --- | --- |
| ![Screenshot 2024-06-04 at 15 51 32](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/d83759ef-5f49-4867-9d92-4f3b6de4fb0a) | ![Screenshot 2024-06-04 at 15 51 22](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/57a08304-d11e-4a18-b217-7c48290e5e8d) |

| If Engineers teach physics course | If no degree subject requirements | 
| --- | --- |
| ![Screenshot 2024-06-04 at 15 50 42](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/d1228976-7640-4504-9e83-76e23a39eef8) | ![Screenshot 2024-06-04 at 15 51 50](https://github.com/DFE-Digital/find-teacher-training-prototype/assets/6122118/40e81b35-311c-47ed-b582-571d9570366e) |

