### PR TITLE
Add pre filtering prototype august 2024

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -142,6 +142,54 @@ display: flex;
 flex-grow: 1; /* default 0 */
 }
 
+.find-search-container {
+  background-color: $govuk-link-colour;
+  margin-bottom: 20px;
+
+  @include govuk-media-query($from: tablet) {
+  margin-bottom: 30px;
+  }
+}
+
+.find-search-content {
+  padding: 20px;
+
+  @include govuk-media-query($from: tablet) {
+    padding: 30px;
+  }
+}
+
+.find-search-color {
+  color: #fff;
+}
+
+.find-flex-container {
+  align-items: flex-end;
+  display: block;
+
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    gap: 20px;;
+  }
+}
+
+.support-flex-container {
+  display: block;
+
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    gap: 20px;;
+  }
+}
+
+.find-item {
+  flex-grow: 1; /* default 0 */
+  margin-bottom: 20px;
+
+  @include govuk-media-query($from: tablet) {
+  }
+}
+
 .fee-bg {
   background-color: #003078;
   margin-bottom: 30px;
@@ -193,6 +241,22 @@ flex-grow: 1; /* default 0 */
   margin-bottom: 30px;
 }
 
+.govuk-accordion--non-uk-home {
+  margin-top: -20px;
+
+  @include govuk-media-query($from: tablet) {
+    margin-top: -10px;
+}
+}
+
+.age-group {
+  margin-bottom: 20px;
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: 0px;
+}
+}
+
 .govuk-accordion__section--non-uk {
   border-left: 5px solid #4c2c92 !important;
   background-color: #f3f2f1;
@@ -219,6 +283,18 @@ flex-grow: 1; /* default 0 */
   border-right: 0px;
   border-top: 0px;
   margin-bottom: 30px;
+}
+
+.govuk-notification-banner--pink {
+  border-bottom: 0px;
+  border-left: 5px solid #f162a3;
+  border-right: 0px;
+  border-top: 0px;
+  margin-bottom: 20px;
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: 30px;
+}
 }
 
 .govuk-notification-banner--non-uk {

--- a/app/routes.js
+++ b/app/routes.js
@@ -235,32 +235,23 @@ router.get('/hackday/questions/degree-grade', questionController.degree_grade_ge
 router.post('/hackday/questions/degree-grade', questionController.degree_grade_post)
 
 /// ------------------------------------------------------------------------ ///
-/// COURSE 2024
+/// PRE-FILTERING 2024
 /// ------------------------------------------------------------------------ ///
 
-router.get('/course-2024', (req, res) => {
-  res.render('./course-2024/index')
+router.get('/pre-filtering-2024', (req, res) => {
+  res.render('./pre-filtering-2024/index')
 })
 
-router.get('/about-provider', (req, res) => {
-  res.render('./course-2024/about-provider')
+router.get('/subject', (req, res) => {
+  res.render('./pre-filtering-2024/subject')
 })
 
-router.get('/about-accredited', (req, res) => {
-  res.render('./course-2024/about-accredited')
+router.get('/subject-fund', (req, res) => {
+  res.render('./pre-filtering-2024/subject-fund')
 })
 
-
-router.get('/results-2024', (req, res) => {
-  res.render('./course-2024/results-2024')
-})
-
-router.get('/training-with-disabilities', (req, res) => {
-  res.render('./course-2024/training-with-disabilities')
-})
-
-router.get('/school-placements', (req, res) => {
-  res.render('./course-2024/school-placements')
+router.get('/subject-half', (req, res) => {
+  res.render('./pre-filtering-2024/subject-half')
 })
 
 /// ------------------------------------------------------------------------ ///

--- a/app/views/pre-filtering-2024/index.njk
+++ b/app/views/pre-filtering-2024/index.njk
@@ -1,0 +1,181 @@
+{% extends "_layouts/default.njk" %}
+
+{% set title = course.name + " (" + course.code + ") with " + course.provider.name %}
+
+{% block pageTitle %}
+{{ "Error: " if showError }}{{ title + " - " if title }}{{ caption + " - " if caption }}{{ serviceName }} - GOV.UK
+{% endblock %}
+
+{% block content %}
+
+  {% include "_includes/nearing-end-of-cycle-banner.njk" %}
+
+<!--Add the dynamic content in here-->
+<!-- may need to refer to the filter.js file to parse the data into a human readable format-->
+
+<div class="find-search-container">
+  <div class="find-search-content">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+
+        <h1 class="govuk-heading-l find-search-color">Find teacher training courses in England</h1>
+
+        <div class="find-flex-container">
+
+          <div class="find-item">
+            <label for="keyword-field" class="govuk-label govuk-label--s find-search-color">
+              Keywords
+            </label>
+            <input id="keyword-field" class="govuk-input" autocomplete="off" type="text" name="keyword">
+          </div>
+
+          <div class="find-item">
+            <label for="keyword-field" class="govuk-label govuk-label--s find-search-color">
+              City, town or postcode
+            </label>
+            <input id="keyword-field" class="govuk-input" autocomplete="off" type="text" name="keyword">
+          </div>
+
+          <div class="find-item">
+            <a href="https://find-teacher-training-courses.service.gov.uk/results?age_group=secondary&applications_open=true&c=England&can_sponsor_visa=false&has_vacancies=true&l=1&latitude=52.4822694&loc=Birmingham%2C+UK&longitude=-1.8900078&lq=Birmingham&qualification%5B%5D=qts&qualification%5B%5D=pgce_with_qts&qualification%5B%5D=pgce+pgde&radius=10&send_courses=false&sortby=distance&study_type%5B%5D=full_time&study_type%5B%5D=part_time&subjects%5B%5D=G1&visa_status=false" role="button" draggable="false" class="govuk-button govuk-button--start govuk-button--inverse" data-module="govuk-button" style="margin-bottom:0;">
+                Search
+            </a>
+          </div>
+
+        </div><!--END flex container-->
+
+      </div><!--END column-->
+    </div><!--END grid row-->
+
+    </div><!--END search content-->
+  </div><!--END search container-->
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third age-group">
+      <p class="govuk-heading-m">
+        Primary
+        <br>
+        <span class="govuk-body-s">
+          Ages 5 to 11
+        </span>
+      </p>
+      <span class="govuk-body">
+        <a href="https://find-teacher-training-courses.service.gov.uk/results?age_group=primary&applications_open=true&c=England&can_sponsor_visa=false&has_vacancies=true&l=2&qualification%5B%5D=qts&qualification%5B%5D=pgce_with_qts&qualification%5B%5D=pgce+pgde&send_courses=false&study_type%5B%5D=full_time&study_type%5B%5D=part_time&subjects%5B%5D=00&subjects%5B%5D=01&subjects%5B%5D=02&subjects%5B%5D=03&subjects%5B%5D=04&subjects%5B%5D=06&subjects%5B%5D=07&visa_status=false">
+          View all primary courses
+        </a>
+      </span>
+    </div><!--END col full-->
+    <div class="govuk-grid-column-one-third age-group">
+      <p class="govuk-heading-m">
+        Secondary
+        <br>
+        <span class="govuk-body-s">
+          Ages 11 to 16
+        </span>
+      </p>
+      <span class="govuk-body">
+        <a href="subject">
+          Browse all secondary subjects
+        </a>
+      </span>
+    </div><!--END col full-->
+    <div class="govuk-grid-column-one-third age-group">
+      <p class="govuk-heading-m">
+        Further education
+        <br>
+        <span class="govuk-body-s">
+          Over 16 and not studying for a degree
+      </span>
+      </p>
+
+      <span class="govuk-body">
+        <a href="https://find-teacher-training-courses.service.gov.uk/results?age_group=further_education&applications_open=true&c=England&can_sponsor_visa=false&has_vacancies=true&l=2&qualification%5B%5D=qts&qualification%5B%5D=pgce_with_qts&qualification%5B%5D=pgce+pgde&send_courses=false&study_type%5B%5D=full_time&study_type%5B%5D=part_time&subjects%5B%5D=41&visa_status=false">
+          View all further education courses
+        </a>
+      </span>
+
+  </div><!--END three cols-->
+</div><!--END grid row-->
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <div class="govuk-accordion govuk-accordion--non-uk-home" data-module="govuk-accordion" id="accordion-default">
+      <div class="govuk-accordion__section govuk-accordion__section--non-uk">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button govuk-accordion__section-button--non-uk" id="accordion-default-heading-1">
+              Non-UK citizens: check if you need visa sponsorship
+            </span>
+          </h2>
+        </div>
+
+        <div id="accordion-default-content-1" class="govuk-accordion__section-content govuk-accordion__section-content--non-uk" style="padding-top:0; padding-bottom:4px;">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+              <p class="govuk-body">
+                To train to teach in England, you will need a visa or immigration status allowing you to study (or work, for salaried courses) in the UK.
+              </p>
+              <p class="govuk-body">
+              <a href="https://getintoteaching.education.gov.uk/non-uk-teachers/visas-for-non-uk-trainees#check-your-status">
+                Check if you need a UK visa</a>.
+              </p>
+              <p>
+                If you need a visa, you should only apply to courses that have visa sponsorship available.
+              </p>
+              <a href="https://find-teacher-training-courses.service.gov.uk/results?age_group=primary&applications_open=true&can_sponsor_visa=true&has_vacancies=true&l=2&subjects%5B%5D=00&visa_status=true" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+                Find courses that offer visa sponsorship
+              </a>
+              <p class="govuk-body">
+                Find out more about
+              <a href="https://getintoteaching.education.gov.uk/non-uk-teachers/train-to-teach-in-england-as-an-international-student">
+                training to teach in England as a non-UK citizen</a>.
+              </p>
+            </div><!--end col 2 thirds-->
+          </div><!--END grid row-->
+        </div><!--END accordion content-->
+
+  </div><!--END col full-->
+</div><!--END grid row-->
+
+<div class="govuk-grid-row">
+
+  <div class="support-flex-container">
+
+    <div class="govuk-grid-column-one-half">
+
+      <div class="govuk-notification-banner govuk-notification-banner--pink" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__content govuk-notification-banner__content--grey">
+        <h3 class="govuk-heading-m">
+          Is teacher training right for me?
+        </h3>
+        <p class="govuk-body">
+          Choosing or changing a career can be a big decision.
+          <a href="https://getintoteaching.education.gov.uk/is-teaching-right-for-me">Find out if teaching is right for you</a>.
+        </p>
+        </div>
+      </div>
+
+    </div>
+    <div class="govuk-grid-column-one-half">
+
+      <div class="govuk-notification-banner govuk-notification-banner--pink" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__content govuk-notification-banner__content--grey">
+        <h3 class="govuk-heading-m">
+          Support and advice
+        </h3>
+        <p class="govuk-body">
+          You can
+          <a href="https://getintoteaching.education.gov.uk/teacher-training-advisers"> get a teacher training adviser</a> or
+          <a href="https://getintoteaching.education.gov.uk/help-and-support"> contact Get Into Teaching</a>
+          for free support.
+        </p>
+        </div>
+      </div>
+    </div>
+
+  </div><!--END support flex container-->
+</div>
+
+{% endblock %}

--- a/app/views/pre-filtering-2024/subject-fund.njk
+++ b/app/views/pre-filtering-2024/subject-fund.njk
@@ -1,0 +1,366 @@
+{% extends "_layouts/default.njk" %}
+
+{% set title = course.name + " (" + course.code + ") with " + course.provider.name %}
+
+{% block pageTitle %}
+{{ "Error: " if showError }}{{ title + " - " if title }}{{ caption + " - " if caption }}{{ serviceName }} - GOV.UK
+{% endblock %}
+
+{% block pageNavigation %}
+{% if referrer == "provider" %}
+  {% set backLinkText = "Back to provider" %}
+{% else %}
+  {% set backLinkText = "Back to search results" %}
+{% endif %}
+{{ govukBackLink({
+  text: backLinkText,
+  href: actions.back
+}) }}
+{% endblock %}
+
+{% block content %}
+
+  {% include "_includes/nearing-end-of-cycle-banner.njk" %}
+
+<!--Add the dynamic content in here-->
+<!-- may need to refer to the filter.js file to parse the data into a human readable format-->
+
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">
+        Browse secondary subjects
+      </h1>
+      <h2 class="govuk-heading-l">
+        Subjects with bursaries or scholarships
+      </h2>
+      <p class="govuk-body">
+        Teachers for these subjects are in demand. You could be eligible for financial support.
+      </p>
+      <p class="govuk-body">
+        <a class="govuk-link govuk-link--no-visited-state" href="https://getintoteaching.education.gov.uk/funding-and-support/scholarships-and-bursaries">
+          Find out whether you are eligible for a bursary or scholarship</a>
+      </p>
+
+      <h3 class="govuk-heading-m">
+        Science, technology, engineering and mathematics (STEM)
+      </h3>
+
+      <div class="govuk-form-group" style="margin-bottom:10px;">
+        <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+          <legend class="govuk-heading-s">
+              Scholarships of £30,000 and bursaries of £28,000 are available
+          </legend>
+          <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+             <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+                Chemistry
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Computing
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Mathematics
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Physics
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+          <legend class="govuk-heading-s">
+              Bursaries of £25,000 are available
+          </legend>
+          <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+             <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+                Biology
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Design and technology
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+
+      <h3 class="govuk-heading-m">
+        Languages and literature
+      </h3>
+
+      <div class="govuk-form-group" style="margin-bottom:10px;">
+          <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+            <legend class="govuk-heading-s">
+                Bursaries of £10,000 are available
+            </legend>
+            <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  English
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+
+        <div class="govuk-form-group" style="margin-bottom:10px;">
+          <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+            <legend class="govuk-heading-s">
+                Scholarships of £27,000 and bursaries of £25,000 are available
+            </legend>
+            <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  French
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  German
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Spanish
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+
+         <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+            <legend class="govuk-heading-s">
+                Bursaries of £25,000 are available
+            </legend>
+            <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Ancient Greek
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Ancient Hebrew
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Italian
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Japanese
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Latin
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Mandarin
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Russian
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Other modern languages
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+
+      <h3 class="govuk-heading-m">
+        Arts, humanities and social sciences
+      </h3>
+
+      <div class="govuk-form-group" style="margin-bottom:10px;">
+        <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+          <legend class="govuk-heading-s">
+              Bursaries of £25,000 are available
+          </legend>
+          <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Geography
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+          <legend class="govuk-heading-s">
+              Bursaries of £10,000 are available
+          </legend>
+          <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Art and design
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Music
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Religious education
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+
+      <h2 class="govuk-heading-l">
+        Other subjects
+      </h2>
+      <p class="govuk-body">
+      You cannot get a bursary or scholarship for these subjects, but you can apply for a student loan.
+      </p>
+      <p class="govuk-body">
+       <a class="govuk-link govuk-link--no-visited-state" href="https://getintoteaching.education.gov.uk/funding-and-support/tuition-fee-and-maintenance-loans">
+          Find out more about student loans for teacher training</a>
+      </p>
+
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+          <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste" name="waste" type="checkbox" value="carcasses">
+              <label class="govuk-label govuk-checkboxes__label" for="waste">
+                Business studies
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Classics
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste" name="waste" type="checkbox" value="carcasses">
+            <label class="govuk-label govuk-checkboxes__label" for="waste">
+              Citizenship
+            </label>
+          </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+                Communication and media studies
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste" name="waste" type="checkbox" value="carcasses">
+            <label class="govuk-label govuk-checkboxes__label" for="waste">
+              Dance
+            </label>
+          </div>
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste" name="waste" type="checkbox" value="carcasses">
+            <label class="govuk-label govuk-checkboxes__label" for="waste">
+            Drama
+            </label>
+          </div>
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+            <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+              Economics
+            </label>
+          </div>
+           <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste" name="waste" type="checkbox" value="carcasses">
+              <label class="govuk-label govuk-checkboxes__label" for="waste">
+                Health and social care
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+            <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+              History
+            </label>
+          </div>
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+            <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+              Philosophy
+            </label>
+          </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+                Physical education
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+            <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+              Psychology
+            </label>
+          </div>
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+            <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+              Science
+            </label>
+          </div>
+            <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+            <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+              Social sciences
+            </label>
+          </div>
+        </fieldset>
+      </div>
+
+      <a href="https://find-teacher-training-courses.service.gov.uk/results?age_group=secondary&applications_open=true&c=England&can_sponsor_visa=false&has_vacancies=true&l=2&qualification%5B%5D=qts&qualification%5B%5D=pgce_with_qts&qualification%5B%5D=pgce&qualification%5B%5D=pgde&qualification%5B%5D=pgde_with_qts&send_courses=false&study_type%5B%5D=full_time&study_type%5B%5D=part_time&study_type%5B%5D=full_time_or_part_time&subjects%5B%5D=G1&visa_status=false" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+        Find secondary courses
+      </a>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/pre-filtering-2024/subject-half.njk
+++ b/app/views/pre-filtering-2024/subject-half.njk
@@ -1,0 +1,366 @@
+{% extends "_layouts/default.njk" %}
+
+{% set title = course.name + " (" + course.code + ") with " + course.provider.name %}
+
+{% block pageTitle %}
+{{ "Error: " if showError }}{{ title + " - " if title }}{{ caption + " - " if caption }}{{ serviceName }} - GOV.UK
+{% endblock %}
+
+{% block pageNavigation %}
+{% if referrer == "provider" %}
+  {% set backLinkText = "Back to provider" %}
+{% else %}
+  {% set backLinkText = "Back to search results" %}
+{% endif %}
+{{ govukBackLink({
+  text: backLinkText,
+  href: actions.back
+}) }}
+{% endblock %}
+
+{% block content %}
+
+  {% include "_includes/nearing-end-of-cycle-banner.njk" %}
+
+<!--Add the dynamic content in here-->
+<!-- may need to refer to the filter.js file to parse the data into a human readable format-->
+
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">
+                Browse secondary subjectsBrowse secondary subjects
+      </h1>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h2 class="govuk-heading-l">
+        Subjects with bursaries or scholarships
+      </h2>
+      <p class="govuk-body">
+        Teachers for these subjects are in demand. You could be eligible for financial support.
+      </p>
+      <p class="govuk-body">
+        <a class="govuk-link govuk-link--no-visited-state" href="https://getintoteaching.education.gov.uk/funding-and-support/scholarships-and-bursaries">
+          Find out whether you are eligible for a bursary or scholarship</a>
+      </p>
+
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+
+      <div class="govuk-form-group" style="margin-bottom:5px;">
+        <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+            <h1 class="govuk-fieldset__heading">
+              Science, technology, engineering and mathematics (STEM)
+            </h1>
+          </legend>
+          <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste" name="waste" type="checkbox" value="carcasses">
+              <label class="govuk-label govuk-checkboxes__label" for="waste">
+                Biology
+              </label>
+            </div>
+             <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+                Chemistry
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Computing
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Design and technology
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Mathematics
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Physics
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+            <h1 class="govuk-fieldset__heading">
+              Arts, humanities and social sciences
+            </h1>
+          </legend>
+          <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste" name="waste" type="checkbox" value="carcasses">
+              <label class="govuk-label govuk-checkboxes__label" for="waste">
+                Art and design
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Geography
+              </label>
+            </div>
+
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste" name="waste" type="checkbox" value="carcasses">
+              <label class="govuk-label govuk-checkboxes__label" for="waste">
+                Music
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Religious education
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+
+    </div>
+      <div class="govuk-grid-column-one-half">
+
+      <div class="govuk-form-group" style="margin-bottom:5px;">
+          <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              <h1 class="govuk-fieldset__heading">
+                Languages and literature
+              </h1>
+            </legend>
+            <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  English
+                </label>
+              </div>
+               <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste" name="waste" type="checkbox" value="carcasses">
+                <label class="govuk-label govuk-checkboxes__label" for="waste">
+                  Ancient Greek
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+                  Ancient Hebrew
+                </label>
+              </div>
+               <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  French
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  German
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Italian
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Japanese
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Latin
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Mandarin
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Russian
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Spanish
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Other modern languages
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+
+      </div>
+    </div>
+
+      <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h2 class="govuk-heading-l">
+        Other subjects
+      </h2>
+      <p class="govuk-body">
+      You cannot get a bursary or scholarship for these subjects, but you can apply for a student loan.
+      </p>
+      <p class="govuk-body">
+       <a class="govuk-link govuk-link--no-visited-state" href="https://getintoteaching.education.gov.uk/funding-and-support/tuition-fee-and-maintenance-loans">
+          Find out more about student loans for teacher training</a>
+      </p>
+
+      </div>
+    </div>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-half">
+
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+          <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste" name="waste" type="checkbox" value="carcasses">
+              <label class="govuk-label govuk-checkboxes__label" for="waste">
+                Business studies
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Classics
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste" name="waste" type="checkbox" value="carcasses">
+            <label class="govuk-label govuk-checkboxes__label" for="waste">
+              Citizenship
+            </label>
+          </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+                Communication and media studies
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste" name="waste" type="checkbox" value="carcasses">
+            <label class="govuk-label govuk-checkboxes__label" for="waste">
+              Dance
+            </label>
+          </div>
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste" name="waste" type="checkbox" value="carcasses">
+            <label class="govuk-label govuk-checkboxes__label" for="waste">
+            Drama
+            </label>
+          </div>
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+            <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+              Economics
+            </label>
+          </div>
+        </fieldset>
+      </div>
+
+    </div>
+    <div class="govuk-grid-column-one-half">
+
+       <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+          <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste" name="waste" type="checkbox" value="carcasses">
+              <label class="govuk-label govuk-checkboxes__label" for="waste">
+                Health and social care
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+            <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+              History
+            </label>
+          </div>
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+            <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+              Philosophy
+            </label>
+          </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+                Physical education
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+            <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+              Psychology
+            </label>
+          </div>
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+            <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+              Science
+            </label>
+          </div>
+            <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+            <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+              Social sciences
+            </label>
+          </div>
+        </fieldset>
+      </div>
+
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <a href="https://find-teacher-training-courses.service.gov.uk/results?age_group=secondary&applications_open=true&c=England&can_sponsor_visa=false&has_vacancies=true&l=2&qualification%5B%5D=qts&qualification%5B%5D=pgce_with_qts&qualification%5B%5D=pgce&qualification%5B%5D=pgde&qualification%5B%5D=pgde_with_qts&send_courses=false&study_type%5B%5D=full_time&study_type%5B%5D=part_time&study_type%5B%5D=full_time_or_part_time&subjects%5B%5D=G1&visa_status=falset" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+      Find secondary courses
+    </a>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/pre-filtering-2024/subject.njk
+++ b/app/views/pre-filtering-2024/subject.njk
@@ -1,0 +1,317 @@
+{% extends "_layouts/default.njk" %}
+
+{% set title = course.name + " (" + course.code + ") with " + course.provider.name %}
+
+{% block pageTitle %}
+{{ "Error: " if showError }}{{ title + " - " if title }}{{ caption + " - " if caption }}{{ serviceName }} - GOV.UK
+{% endblock %}
+
+{% block pageNavigation %}
+{% if referrer == "provider" %}
+  {% set backLinkText = "Back to provider" %}
+{% else %}
+  {% set backLinkText = "Back to search results" %}
+{% endif %}
+{{ govukBackLink({
+  text: backLinkText,
+  href: actions.back
+}) }}
+{% endblock %}
+
+{% block content %}
+
+  {% include "_includes/nearing-end-of-cycle-banner.njk" %}
+
+<!--Add the dynamic content in here-->
+<!-- may need to refer to the filter.js file to parse the data into a human readable format-->
+
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">
+        Browse secondary subjects
+      </h1>
+      <h2 class="govuk-heading-l">
+        Subjects with bursaries or scholarships
+      </h2>
+      <p class="govuk-body">
+        Teachers for these subjects are in demand. You could be eligible for financial support.
+      </p>
+      <p class="govuk-body">
+        <a class="govuk-link govuk-link--no-visited-state" href="https://getintoteaching.education.gov.uk/funding-and-support/scholarships-and-bursaries">
+          Find out whether you are eligible for a bursary or scholarship</a>
+      </p>
+
+      <h3 class="govuk-heading-m">
+        Science, technology, engineering and mathematics (STEM)
+      </h3>
+
+      <div class="govuk-form-group" style="margin-bottom:10px;">
+        <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+          <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+              <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+                Biology
+              </label>
+            </div>
+             <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+                Chemistry
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Computing
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Design and technology
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Mathematics
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Physics
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+
+      <h3 class="govuk-heading-m">
+        Languages and literature
+      </h3>
+
+         <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+            <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  English
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Ancient Greek
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Ancient Hebrew
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  French
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  German
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Italian
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Japanese
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Latin
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Mandarin
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Russian
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Spanish
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Other modern languages
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+
+      <h3 class="govuk-heading-m">
+        Arts, humanities and social sciences
+      </h3>
+
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+          <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Art and design
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Geography
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Music
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Religious education
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+
+      <h2 class="govuk-heading-l">
+        Other subjects
+      </h2>
+      <p class="govuk-body">
+      You cannot get a bursary or scholarship for these subjects, but you can apply for a student loan.
+      </p>
+      <p class="govuk-body">
+       <a class="govuk-link govuk-link--no-visited-state" href="https://getintoteaching.education.gov.uk/funding-and-support/tuition-fee-and-maintenance-loans">
+          Find out more about student loans for teacher training</a>
+      </p>
+
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+          <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste" name="waste" type="checkbox" value="carcasses">
+              <label class="govuk-label govuk-checkboxes__label" for="waste">
+                Business studies
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                Classics
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste" name="waste" type="checkbox" value="carcasses">
+            <label class="govuk-label govuk-checkboxes__label" for="waste">
+              Citizenship
+            </label>
+          </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+                Communication and media studies
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste" name="waste" type="checkbox" value="carcasses">
+            <label class="govuk-label govuk-checkboxes__label" for="waste">
+              Dance
+            </label>
+          </div>
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste" name="waste" type="checkbox" value="carcasses">
+            <label class="govuk-label govuk-checkboxes__label" for="waste">
+            Drama
+            </label>
+          </div>
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+            <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+              Economics
+            </label>
+          </div>
+           <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste" name="waste" type="checkbox" value="carcasses">
+              <label class="govuk-label govuk-checkboxes__label" for="waste">
+                Health and social care
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+            <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+              History
+            </label>
+          </div>
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+            <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+              Philosophy
+            </label>
+          </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+              <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+                Physical education
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+            <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+              Psychology
+            </label>
+          </div>
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+            <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+              Science
+            </label>
+          </div>
+            <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+            <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+              Social sciences
+            </label>
+          </div>
+        </fieldset>
+      </div>
+
+      <a href="https://find-teacher-training-courses.service.gov.uk/results?age_group=secondary&applications_open=true&c=England&can_sponsor_visa=false&has_vacancies=true&l=2&qualification%5B%5D=qts&qualification%5B%5D=pgce_with_qts&qualification%5B%5D=pgce&qualification%5B%5D=pgde&qualification%5B%5D=pgde_with_qts&send_courses=false&study_type%5B%5D=full_time&study_type%5B%5D=part_time&study_type%5B%5D=full_time_or_part_time&subjects%5B%5D=G1&visa_status=false" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+        Find secondary courses
+      </a>
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
## Added a new pre-filtering section

While we are working out what to test for the next phase of work, I have added a separate pre-filtering folder to the directory, which includes a hard coded prototype. 

The plan would be to make the prototype more dynamic when the design is finalised, move relevant files into the correct version folder, and remove this folder.

| Example of the design |
| --- |
| ![localhost_3010_pre-filtering-2024 (1)](https://github.com/user-attachments/assets/44ef2058-4ee6-412f-a4ee-5a84f959cd62) |
